### PR TITLE
Use `BitSet` for Tracer input set

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,5 +26,4 @@ trace_input
 The following utilities can be used to extract input indices from [`Tracer`](@ref)s:
 ```@docs
 inputs
-sortedinputs
 ```

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -9,7 +9,7 @@ include("connectivity.jl")
 
 export Tracer
 export tracer, trace_input
-export inputs, sortedinputs
+export inputs
 export connectivity
 
 end # module

--- a/src/tracer.jl
+++ b/src/tracer.jl
@@ -103,7 +103,6 @@ tracer(inds...)                             = tracer(inds)
     inputs(tracer)
 
 Return raw `UInt64` input indices of a [`Tracer`](@ref).
-See also [`sortedinputs`](@ref).
 
 ## Example
 ```jldoctest

--- a/src/tracer.jl
+++ b/src/tracer.jl
@@ -74,10 +74,10 @@ julia> M * [x, y]
 ```
 """
 struct Tracer <: Number
-    inputs::Set{UInt64} # indices of connected, enumerated inputs
+    inputs::BitSet # indices of connected, enumerated inputs
 end
 
-const EMPTY_TRACER = Tracer(Set{UInt64}())
+const EMPTY_TRACER = Tracer(BitSet())
 
 # We have to be careful when defining constructors:
 # Generic code expecting "regular" numbers `x` will sometimes convert them 
@@ -94,8 +94,8 @@ uniontracer(a::Tracer, b::Tracer) = Tracer(union(a.inputs, b.inputs))
 
 Convenience constructor for [`Tracer`](@ref) from input indices.
 """
-tracer(index::Integer) = Tracer(Set{UInt64}(index))
-tracer(inds::NTuple{N,<:Integer}) where {N} = Tracer(Set{UInt64}(inds))
+tracer(index::Integer) = Tracer(BitSet(index))
+tracer(inds::NTuple{N,<:Integer}) where {N} = Tracer(BitSet(inds))
 tracer(inds...)                             = tracer(inds)
 
 # Utilities for accessing input indices
@@ -111,42 +111,14 @@ julia> t = tracer(1, 2, 4)
 Tracer(1, 2, 4)
 
 julia> inputs(t)
-3-element Vector{UInt64}:
- 0x0000000000000004
- 0x0000000000000002
- 0x0000000000000001
-```
-"""
-inputs(t::Tracer) = collect(keys(t.inputs.dict))
-
-"""
-    sortedinputs(tracer)
-    sortedinputs([T=Int], tracer)
-
-Return sorted input indices of a [`Tracer`](@ref).
-See also [`inputs`](@ref).
-
-## Example
-```jldoctest
-julia> t = tracer(1, 2, 4)
-Tracer(1, 2, 4)
-
-julia> sortedinputs(t)
 3-element Vector{Int64}:
  1
  2
  4
-
-julia> sortedinputs(UInt8, t)
-3-element Vector{UInt8}:
- 0x01
- 0x02
- 0x04
 ```
 """
-sortedinputs(t::Tracer) = sortedinputs(Int, t)
-sortedinputs(T::Type, t::Tracer) = convert.(T, sort!(inputs(t)))
+inputs(t::Tracer) = collect(t.inputs)
 
 function Base.show(io::IO, t::Tracer)
-    return Base.show_delim_array(io, sortedinputs(Int, t), "Tracer(", ',', ')', true)
+    return Base.show_delim_array(io, inputs(t), "Tracer(", ',', ')', true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,16 +44,16 @@ DocMeta.setdocmeta!(
         # Matrix multiplication
         A = rand(1, 3)
         yt = only(A * xt)
-        @test sortedinputs(yt) == [1, 2, 3]
+        @test inputs(yt) == [1, 2, 3]
 
         @test connectivity(x -> only(A * x), x) ≈ [1 1 1]
 
         # Custom functions
         f(x) = [x[1]^2, 2 * x[1] * x[2]^2, sin(x[3])]
         yt = f(xt)
-        @test sortedinputs(yt[1]) == [1]
-        @test sortedinputs(yt[2]) == [1, 2]
-        @test sortedinputs(yt[3]) == [3]
+        @test inputs(yt[1]) == [1]
+        @test inputs(yt[2]) == [1, 2]
+        @test inputs(yt[3]) == [3]
 
         @test connectivity(f, x) ≈ [1 0 0; 1 1 0; 0 0 1]
 


### PR DESCRIPTION
@gdalle, you were sceptical on this topic, but it looks like BitSets improve the performance even further, cutting runtime in half:
```Julia
julia> include("test/benchmark.jl")
[ Info: Benchmarking Brusselator of size 6 with tracer...
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  27.000 μs …  2.795 ms  ┊ GC (min … max):  0.00% … 98.14%
 Time  (median):     28.917 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   33.634 μs ± 96.856 μs  ┊ GC (mean ± σ):  12.10% ±  4.15%

     ▂▆██▅▁    ▁▂▁                                             
  ▁▂▅███████▆▆▇███▇▆▅▃▃▂▂▂▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  27 μs           Histogram: frequency by time        39.4 μs <

 Memory estimate: 108.19 KiB, allocs estimate: 1252.
 
[ Info: Benchmarking Brusselator of size 6 with symbolics...
BenchmarkTools.Trial: 2253 samples with 1 evaluation.
 Range (min … max):  2.048 ms …   4.927 ms  ┊ GC (min … max): 0.00% … 55.67%
 Time  (median):     2.085 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.218 ms ± 574.703 μs  ┊ GC (mean ± σ):  5.77% ± 11.90%

  █▇▁                                                       ▂  
  ███▃▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃██ █
  2.05 ms      Histogram: log(frequency) by time      4.77 ms <

 Memory estimate: 2.86 MiB, allocs estimate: 41727.
```
Down from `76.298 μs ± 174.080 μs` in #4.
___
```Julia
[ Info: Benchmarking Brusselator of size 24 with tracer...
BenchmarkTools.Trial: 7975 samples with 1 evaluation.
 Range (min … max):  507.959 μs …   3.436 ms  ┊ GC (min … max):  0.00% … 79.82%
 Time  (median):     545.792 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   626.101 μs ± 416.698 μs  ┊ GC (mean ± σ):  12.28% ± 14.41%

  ██▂                                                        ▁  ▁
  ███▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▃▅▆▇████ █
  508 μs        Histogram: log(frequency) by time       2.88 ms <

 Memory estimate: 2.15 MiB, allocs estimate: 23416.
 
[ Info: Benchmarking Brusselator of size 24 with symbolics...
BenchmarkTools.Trial: 131 samples with 1 evaluation.
 Range (min … max):  34.386 ms … 43.780 ms  ┊ GC (min … max):  0.00% … 12.79%
 Time  (median):     38.694 ms              ┊ GC (median):    10.20%
 Time  (mean ± σ):   38.394 ms ±  2.239 ms  ┊ GC (mean ± σ):   8.32% ±  4.78%

   ▇                       ▂ ▄ █   ▂                           
  ▅█▇▅▁▅▁▃▃▃▃▇▁▁▁▃▃▇█▆▆▇▅▃██▃█▅█▆█▆█▃▃▆▆▃▅▃▃▆▃▁▅▅▁▁▇▁▁▃▁▁▁▁▁▅ ▃
  34.4 ms         Histogram: frequency by time        43.7 ms <

 Memory estimate: 45.80 MiB, allocs estimate: 672702.
```
Down from `1.315 ms ± 688.047 μs` in #4.
___
```Julia
[ Info: Benchmarking NNlib.conv with tracer...
BenchmarkTools.Trial: 46 samples with 1 evaluation.
 Range (min … max):   95.325 ms … 218.397 ms  ┊ GC (min … max): 11.79% … 58.32%
 Time  (median):     105.045 ms               ┊ GC (median):    17.90%
 Time  (mean ± σ):   108.741 ms ±  20.552 ms  ┊ GC (mean ± σ):  20.71% ±  8.62%

  ▃█▃  ▁▃ ▄                                                      
  ███▆▇██▇█▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄ ▁
  95.3 ms          Histogram: frequency by time          218 ms <

 Memory estimate: 505.94 MiB, allocs estimate: 3345683.
```
Symbolics fails on `NNlib.conv`.