### PR TITLE
Order classification

### DIFF
--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -5,6 +5,7 @@ import SparseArrays: sparse
 include("tracer.jl")
 include("conversion.jl")
 include("operators.jl")
+include("overload_tracer.jl")
 include("connectivity.jl")
 
 export Tracer

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -11,9 +11,7 @@ Base.convert(::Type{Tracer}, t::Tracer)   = t
 Base.convert(::Type{<:Number}, t::Tracer) = t
 
 ## Array constructors
-Base.zero(::Tracer)       = EMPTY_TRACER
 Base.zero(::Type{Tracer}) = EMPTY_TRACER
-Base.one(::Tracer)        = EMPTY_TRACER
 Base.one(::Type{Tracer})  = EMPTY_TRACER
 
 Base.similar(a::Array{Tracer,1})                               = zeros(Tracer, size(a, 1))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -150,7 +150,8 @@ ops_2_to_1_ffc = (
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_ffz = (
-    :+, :-, 
+    :+, :-,
+    :mod, :rem,
 )
 
 # ops_2_to_1_szz: 
@@ -175,7 +176,9 @@ ops_2_to_1_zsz = ()
 # ∂f/∂y    == 0
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
-ops_2_to_1_fzz = ()
+ops_2_to_1_fzz = (
+    :copysign, :flipsign,
+)
 
 # ops_2_to_1_zfz: 
 # ∂f/∂x    == 0
@@ -183,9 +186,7 @@ ops_2_to_1_fzz = ()
 # ∂f/∂y    != 0
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
-ops_2_to_1_zfz = (
-    :rem,
-)
+ops_2_to_1_zfz = ()
 
 # ops_2_to_1_zfz: 
 # ∂f/∂x    == 0
@@ -196,8 +197,6 @@ ops_2_to_1_zfz = (
 ops_2_to_1_zzz = (
     # division
     :div, :fld, :fld1, :cld, 
-    :mod,
-    :copysign, :flipsign,
 )
 
 ops_2_to_1 = union(

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,19 +1,20 @@
 ## Operator definitions
 
 # We use a system of letters to categorize operators:
-# * z: first- and second-order derivatives (FOD, SOD) are zero
-# * f: FOD is non-zero, SOD is zero
-# * s: FOD is non-zero, SOD is non-zero
+#   z: first- and second-order derivatives (FOD, SOD) are zero
+#   f: FOD ∂f/∂x is non-zero, SOD ∂²f/∂x² is zero 
+#   s: FOD ∂f/∂x is non-zero, SOD ∂²f/∂x² is non-zero
+#   c: Cross-derivative ∂²f/∂x∂y is non-zero
 
-#! format: on
+#! format: off
 
 ##=================================#
 # Operators for functions f: ℝ → ℝ #
 #==================================#
 
 # ops_1_to_1_s: 
-# ∂f/∂x   ≠ 0
-# ∂²f/∂x² ≠ 0
+# ∂f/∂x   != 0
+# ∂²f/∂x² != 0
 ops_1_to_1_s = (
     # trigonometric functions
     :deg2rad, :rad2deg,
@@ -43,23 +44,27 @@ ops_1_to_1_s = (
 )
 
 # ops_1_to_1_f:
-# ∂f/∂x   ≠ 0
-# ∂²f/∂x² = 0
+# ∂f/∂x   != 0
+# ∂²f/∂x² == 0
 ops_1_to_1_f = (
+    :+, :-,
     # absolute values
-    :abs
+    :abs,
     # other
-    :mod2pi
+    :mod2pi, :prevfloat, :nextfloat,
 )
 
 # ops_1_to_1_z:
-# ∂f/∂x   = 0
-# ∂²f/∂x² = 0
+# ∂f/∂x   == 0
+# ∂²f/∂x² == 0
 ops_1_to_1_z = (
     # rounding
-    :round, :floor, :ceil, :trunc,4
+    :round, :floor, :ceil, :trunc,
     # other
-    :sign
+    :sign,
+    # constants
+    :zero, :one,
+    :eps, :floatmin, :floatmax, :maxintfloat, :typemax
 )
 
 ops_1_to_1 = union(
@@ -72,196 +77,235 @@ ops_1_to_1 = union(
 # Operators for functions f: ℝ² → ℝ #
 #===================================#
 
-ops_2_to_1 = (
-    :+, :-, :*, :/, 
-    # division
-    :div, :fld, :cld, 
-    # modulo
-    :mod, :rem,
-    # exponentials
-    :ldexp, 
-    # sign
-    :copysign, :flipsign,
-    # other
+# ops_2_to_1_ssc: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  != 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  != 0
+# ∂²f/∂x∂y != 0
+ops_2_to_1_ssc = (
     :hypot,
 )
 
-# ops_2_to_1_sss: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  ≠ 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  ≠ 0 
-# ∂²f/∂x∂y ≠ 0 
-ops_2_to_1_sss = ()
-
 # ops_2_to_1_ssz: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  ≠ 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  ≠ 0 
-# ∂²f/∂x∂y = 0 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  != 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  != 0
+# ∂²f/∂x∂y == 0
 ops_2_to_1_ssz = ()
 
-# ops_2_to_1_sfs: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  ≠ 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  = 0 
-# ∂²f/∂x∂y ≠ 0 
-ops_2_to_1_sfs = ()
+# ops_2_to_1_sfc: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  != 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y != 0
+ops_2_to_1_sfc = ()
 
 # ops_2_to_1_sfz: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  ≠ 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  = 0 
-# ∂²f/∂x∂y = 0 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  != 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
 ops_2_to_1_sfz = ()
 
-# ops_2_to_1_szz: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  ≠ 0 
-# ∂f/∂y    = 0 
-# ∂²f/∂y²  = 0 
-# ∂²f/∂x∂y ≠ 0 
-ops_2_to_1_szz = ()
-
-# ops_2_to_1_fss: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  = 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  ≠ 0 
-# ∂²f/∂x∂y ≠ 0 
-ops_2_to_1_fss = ()
+# ops_2_to_1_fsc: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  != 0
+# ∂²f/∂x∂y != 0
+ops_2_to_1_fsc = (
+    :/, 
+    # exponentials
+    :ldexp, 
+)
 
 # ops_2_to_1_fsz: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  = 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  ≠ 0 
-# ∂²f/∂x∂y = 0 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  != 0
+# ∂²f/∂x∂y == 0
 ops_2_to_1_fsz = ()
 
+# ops_2_to_1_ffc: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y != 0
+ops_2_to_1_ffc = (
+    :*, 
+)
+
+# ops_2_to_1_ffz: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
+ops_2_to_1_ffz = (
+    :+, :-, 
+)
+
+# ops_2_to_1_szz: 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  != 0
+# ∂f/∂y    == 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
+ops_2_to_1_szz = ()
+
 # ops_2_to_1_zsz: 
-# ∂f/∂x    = 0 
-# ∂²f/∂x²  = 0 
-# ∂f/∂y    ≠ 0 
-# ∂²f/∂y²  ≠ 0 
-# ∂²f/∂x∂y = 0 
-ops_2_to_1_fss = ()
+# ∂f/∂x    == 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  != 0
+# ∂²f/∂x∂y == 0
+ops_2_to_1_zsz = ()
 
 # ops_2_to_1_fzz: 
-# ∂f/∂x    ≠ 0 
-# ∂²f/∂x²  = 0 
-# ∂f/∂y    = 0 
-# ∂²f/∂y²  = 0 
-# ∂²f/∂x∂y = 0 
+# ∂f/∂x    != 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    == 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
 ops_2_to_1_fzz = ()
 
-ops_2_to_1_ss = (
-    # trigonometric
-    :sincos,
-    :sincosd,
-    :sincospi,
-    # exponentials
-    :frexp,
+# ops_2_to_1_zfz: 
+# ∂f/∂x    == 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    != 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
+ops_2_to_1_zfz = ()
+
+# ops_2_to_1_zfz: 
+# ∂f/∂x    == 0
+# ∂²f/∂x²  == 0
+# ∂f/∂y    == 0
+# ∂²f/∂y²  == 0
+# ∂²f/∂x∂y == 0
+ops_2_to_1_zzz = (
+    # division
+    :div, :fld, :fld1, :cld, 
+    # modulo and friends
+    :mod, :rem,
+    # sign
+    :copysign, :flipsign,
 )
 
 ops_2_to_1 = union(
-    ops_2_to_1_ss,
-    ops_2_to_1_sf,
-    ops_2_to_1_sz,
-    ops_2_to_1_fs,
-    ops_2_to_1_ff,
-    ops_2_to_1_fz,
-    ops_2_to_1_zs,
-    ops_2_to_1_zf,
-    ops_2_to_1_zz,   
-)
+    # Including second-order only
+    ops_2_to_1_ssc,
+    ops_2_to_1_ssz,
 
+    # Including second- and first-order
+    ops_2_to_1_sfc,
+    ops_2_to_1_sfz,
+    
+    ops_2_to_1_fsc,
+    ops_2_to_1_fsz,
+    
+    # Including first-order only
+    ops_2_to_1_ffc,
+    ops_2_to_1_ffz,
+
+    # Including zero-order
+    ops_2_to_1_szz,
+    ops_2_to_1_zsz,
+
+    ops_2_to_1_fzz,
+    ops_2_to_1_zfz,
+
+    ops_2_to_1_zzz,   
+)
 
 ##==================================#
 # Operators for functions f: ℝ → ℝ² #
 #===================================#
 
 # ops_1_to_2_ss: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² ≠ 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² ≠ 0 
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² != 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² != 0
 ops_1_to_2_ss = (
     # trigonometric
     :sincos,
     :sincosd,
     :sincospi,
-    # exponentials
-    :frexp,
 )
 
 # ops_1_to_2_sf: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² ≠ 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² = 0 
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² != 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² == 0
 ops_1_to_2_sf = ()
 
 # ops_1_to_2_sz: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² ≠ 0 
-# ∂f₂/∂x   = 0 
-# ∂²f₂/∂x² = 0 
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² != 0
+# ∂f₂/∂x   == 0
+# ∂²f₂/∂x² == 0
 ops_1_to_2_sz = ()
 
 # ops_1_to_2_fs: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² ≠ 0 
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² != 0
 ops_1_to_2_fs = ()
 
 # ops_1_to_2_ff: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² = 0 
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² == 0
 ops_1_to_2_ff = ()
 
 # ops_1_to_2_fz: 
-# ∂f₁/∂x   ≠ 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   = 0 
-# ∂²f₂/∂x² = 0 
-ops_1_to_2_fz = ()
+# ∂f₁/∂x   != 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   == 0
+# ∂²f₂/∂x² == 0
+ops_1_to_2_fz = (
+    :frexp,
+)
 
 # ops_1_to_2_zs: 
-# ∂f₁/∂x   = 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² ≠ 0 
+# ∂f₁/∂x   == 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² != 0
 ops_1_to_2_zs = ()
 
 # ops_1_to_2_zf: 
-# ∂f₁/∂x   = 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   ≠ 0 
-# ∂²f₂/∂x² = 0 
+# ∂f₁/∂x   == 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   != 0
+# ∂²f₂/∂x² == 0
 ops_1_to_2_zf = ()
 
 # ops_1_to_2_zz: 
-# ∂f₁/∂x   = 0 
-# ∂²f₁/∂x² = 0 
-# ∂f₂/∂x   = 0 
-# ∂²f₂/∂x² = 0 
+# ∂f₁/∂x   == 0
+# ∂²f₁/∂x² == 0
+# ∂f₂/∂x   == 0
+# ∂²f₂/∂x² == 0
 ops_1_to_2_zz = ()
 
 ops_1_to_2 = union(
     ops_1_to_2_ss,
     ops_1_to_2_sf,
-    ops_1_to_2_sz,
     ops_1_to_2_fs,
     ops_1_to_2_ff,
-    ops_1_to_2_fz,
+    ops_1_to_2_sz,
     ops_1_to_2_zs,
+    ops_1_to_2_fz,
     ops_1_to_2_zf,
     ops_1_to_2_zz,   
 )

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -66,7 +66,9 @@ ops_1_to_1_z = (
 # these are kept separate from ops_1_to_1_z.
 ops_1_to_1_const = (
     :zero, :one,
-    :eps, :floatmin, :floatmax, :maxintfloat, :typemax
+    :eps, 
+    :typemax,
+    # :floatmin, :floatmax, :maxintfloat, 
 )
 
 ops_1_to_1 = union(

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -122,7 +122,7 @@ ops_2_to_1_sfz = ()
 # ∂²f/∂x∂y != 0
 ops_2_to_1_fsc = (
     :/, 
-    :ldexp, 
+    # :ldexp,  # TODO: removed for now
 )
 
 # ops_2_to_1_fsz: 
@@ -274,7 +274,7 @@ ops_1_to_2_ff = ()
 # ∂f₂/∂x   == 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_fz = (
-    :frexp,
+    # :frexp,  # TODO: removed for now
 )
 
 # ops_1_to_2_zs: 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -62,7 +62,13 @@ ops_1_to_1_z = (
     :round, :floor, :ceil, :trunc,
     # other
     :sign,
-    # constants
+)
+
+# Functions returning constant output
+# that only depends on the input type.
+# For the purpose of operator overloading,
+# these are kept separate from ops_1_to_1_z.
+ops_1_to_1_const = (
     :zero, :one,
     :eps, :floatmin, :floatmax, :maxintfloat, :typemax
 )
@@ -71,6 +77,7 @@ ops_1_to_1 = union(
     ops_1_to_1_s, 
     ops_1_to_1_f, 
     ops_1_to_1_z,
+    ops_1_to_1_const,
 )
 
 ##==================================#

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -48,9 +48,7 @@ ops_1_to_1_s = (
 # ∂²f/∂x² == 0
 ops_1_to_1_f = (
     :+, :-,
-    # absolute values
     :abs,
-    # other
     :mod2pi, :prevfloat, :nextfloat,
 )
 
@@ -58,9 +56,7 @@ ops_1_to_1_f = (
 # ∂f/∂x   == 0
 # ∂²f/∂x² == 0
 ops_1_to_1_z = (
-    # rounding
     :round, :floor, :ceil, :trunc,
-    # other
     :sign,
 )
 
@@ -126,7 +122,6 @@ ops_2_to_1_sfz = ()
 # ∂²f/∂x∂y != 0
 ops_2_to_1_fsc = (
     :/, 
-    # exponentials
     :ldexp, 
 )
 
@@ -188,7 +183,9 @@ ops_2_to_1_fzz = ()
 # ∂f/∂y    != 0
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
-ops_2_to_1_zfz = ()
+ops_2_to_1_zfz = (
+    :rem,
+)
 
 # ops_2_to_1_zfz: 
 # ∂f/∂x    == 0
@@ -199,9 +196,7 @@ ops_2_to_1_zfz = ()
 ops_2_to_1_zzz = (
     # division
     :div, :fld, :fld1, :cld, 
-    # modulo and friends
-    :mod, :rem,
-    # sign
+    :mod,
     :copysign, :flipsign,
 )
 
@@ -241,7 +236,6 @@ ops_2_to_1 = union(
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² != 0
 ops_1_to_2_ss = (
-    # trigonometric
     :sincos,
     :sincosd,
     :sincospi,

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -17,7 +17,6 @@
 # ∂²f/∂x² != 0
 ops_1_to_1_s = (
     # trigonometric functions
-    :deg2rad, :rad2deg,
     :cos, :cosd, :cosh, :cospi, :cosc, 
     :sin, :sind, :sinh, :sinpi, :sinc, 
     :tan, :tand, :tanh,
@@ -40,7 +39,7 @@ ops_1_to_1_s = (
     # absolute values
     :abs2,
     # other
-    :inv, :hypot,
+    :inv,
 )
 
 # ops_1_to_1_f:
@@ -48,7 +47,8 @@ ops_1_to_1_s = (
 # ∂²f/∂x² == 0
 ops_1_to_1_f = (
     :+, :-,
-    :abs,
+    :abs, :hypot,
+    :deg2rad, :rad2deg,
     :mod2pi, :prevfloat, :nextfloat,
 )
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,23 +1,20 @@
 ## Operator definitions
 
-#! format: off
-ops_2_to_1 = (
-    :+, :-, :*, :/, 
-    # division
-    :div, :fld, :cld, 
-    # modulo
-    :mod, :rem,
-    # trigonometric functions
-    :atan, :atand,
-    # exponentials
-    :ldexp, 
-    # sign
-    :copysign, :flipsign,
-    # other
-    :hypot,
-)
+# We use a system of letters to categorize operators:
+# * z: first- and second-order derivatives (FOD, SOD) are zero
+# * f: FOD is non-zero, SOD is zero
+# * s: FOD is non-zero, SOD is non-zero
 
-ops_1_to_1 = (
+#! format: on
+
+##=================================#
+# Operators for functions f: ℝ → ℝ #
+#==================================#
+
+# ops_1_to_1_s: 
+# ∂f/∂x   ≠ 0
+# ∂²f/∂x² ≠ 0
+ops_1_to_1_s = (
     # trigonometric functions
     :deg2rad, :rad2deg,
     :cos, :cosd, :cosh, :cospi, :cosc, 
@@ -40,14 +37,128 @@ ops_1_to_1 = (
     # roots
     :sqrt, :cbrt,
     # absolute values
-    :abs, :abs2,
-    # rounding
-    :round, :floor, :ceil, :trunc,
+    :abs2,
     # other
-    :inv, :signbit, :hypot, :sign, :mod2pi
+    :inv, :hypot,
 )
 
-ops_1_to_2 = (
+# ops_1_to_1_f:
+# ∂f/∂x   ≠ 0
+# ∂²f/∂x² = 0
+ops_1_to_1_f = (
+    # absolute values
+    :abs
+    # other
+    :mod2pi
+)
+
+# ops_1_to_1_z:
+# ∂f/∂x   = 0
+# ∂²f/∂x² = 0
+ops_1_to_1_z = (
+    # rounding
+    :round, :floor, :ceil, :trunc,4
+    # other
+    :sign
+)
+
+ops_1_to_1 = union(
+    ops_1_to_1_s, 
+    ops_1_to_1_f, 
+    ops_1_to_1_z,
+)
+
+##==================================#
+# Operators for functions f: ℝ² → ℝ #
+#===================================#
+
+ops_2_to_1 = (
+    :+, :-, :*, :/, 
+    # division
+    :div, :fld, :cld, 
+    # modulo
+    :mod, :rem,
+    # exponentials
+    :ldexp, 
+    # sign
+    :copysign, :flipsign,
+    # other
+    :hypot,
+)
+
+# ops_2_to_1_sss: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  ≠ 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  ≠ 0 
+# ∂²f/∂x∂y ≠ 0 
+ops_2_to_1_sss = ()
+
+# ops_2_to_1_ssz: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  ≠ 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  ≠ 0 
+# ∂²f/∂x∂y = 0 
+ops_2_to_1_ssz = ()
+
+# ops_2_to_1_sfs: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  ≠ 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  = 0 
+# ∂²f/∂x∂y ≠ 0 
+ops_2_to_1_sfs = ()
+
+# ops_2_to_1_sfz: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  ≠ 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  = 0 
+# ∂²f/∂x∂y = 0 
+ops_2_to_1_sfz = ()
+
+# ops_2_to_1_szz: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  ≠ 0 
+# ∂f/∂y    = 0 
+# ∂²f/∂y²  = 0 
+# ∂²f/∂x∂y ≠ 0 
+ops_2_to_1_szz = ()
+
+# ops_2_to_1_fss: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  = 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  ≠ 0 
+# ∂²f/∂x∂y ≠ 0 
+ops_2_to_1_fss = ()
+
+# ops_2_to_1_fsz: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  = 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  ≠ 0 
+# ∂²f/∂x∂y = 0 
+ops_2_to_1_fsz = ()
+
+# ops_2_to_1_zsz: 
+# ∂f/∂x    = 0 
+# ∂²f/∂x²  = 0 
+# ∂f/∂y    ≠ 0 
+# ∂²f/∂y²  ≠ 0 
+# ∂²f/∂x∂y = 0 
+ops_2_to_1_fss = ()
+
+# ops_2_to_1_fzz: 
+# ∂f/∂x    ≠ 0 
+# ∂²f/∂x²  = 0 
+# ∂f/∂y    = 0 
+# ∂²f/∂y²  = 0 
+# ∂²f/∂x∂y = 0 
+ops_2_to_1_fzz = ()
+
+ops_2_to_1_ss = (
     # trigonometric
     :sincos,
     :sincosd,
@@ -55,38 +166,103 @@ ops_1_to_2 = (
     # exponentials
     :frexp,
 )
+
+ops_2_to_1 = union(
+    ops_2_to_1_ss,
+    ops_2_to_1_sf,
+    ops_2_to_1_sz,
+    ops_2_to_1_fs,
+    ops_2_to_1_ff,
+    ops_2_to_1_fz,
+    ops_2_to_1_zs,
+    ops_2_to_1_zf,
+    ops_2_to_1_zz,   
+)
+
+
+##==================================#
+# Operators for functions f: ℝ → ℝ² #
+#===================================#
+
+# ops_1_to_2_ss: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² ≠ 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² ≠ 0 
+ops_1_to_2_ss = (
+    # trigonometric
+    :sincos,
+    :sincosd,
+    :sincospi,
+    # exponentials
+    :frexp,
+)
+
+# ops_1_to_2_sf: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² ≠ 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_sf = ()
+
+# ops_1_to_2_sz: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² ≠ 0 
+# ∂f₂/∂x   = 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_sz = ()
+
+# ops_1_to_2_fs: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² ≠ 0 
+ops_1_to_2_fs = ()
+
+# ops_1_to_2_ff: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_ff = ()
+
+# ops_1_to_2_fz: 
+# ∂f₁/∂x   ≠ 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   = 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_fz = ()
+
+# ops_1_to_2_zs: 
+# ∂f₁/∂x   = 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² ≠ 0 
+ops_1_to_2_zs = ()
+
+# ops_1_to_2_zf: 
+# ∂f₁/∂x   = 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   ≠ 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_zf = ()
+
+# ops_1_to_2_zz: 
+# ∂f₁/∂x   = 0 
+# ∂²f₁/∂x² = 0 
+# ∂f₂/∂x   = 0 
+# ∂²f₂/∂x² = 0 
+ops_1_to_2_zz = ()
+
+ops_1_to_2 = union(
+    ops_1_to_2_ss,
+    ops_1_to_2_sf,
+    ops_1_to_2_sz,
+    ops_1_to_2_fs,
+    ops_1_to_2_ff,
+    ops_1_to_2_fz,
+    ops_1_to_2_zs,
+    ops_1_to_2_zf,
+    ops_1_to_2_zz,   
+)
 #! format: on
-
-for fn in ops_1_to_1
-    @eval Base.$fn(t::Tracer) = t
-end
-
-for fn in ops_1_to_2
-    @eval Base.$fn(t::Tracer) = (t, t)
-end
-
-for fn in ops_2_to_1
-    @eval Base.$fn(a::Tracer, b::Tracer) = uniontracer(a, b)
-    @eval Base.$fn(t::Tracer, ::Number) = t
-    @eval Base.$fn(::Number, t::Tracer) = t
-end
-
-# Extra types required for exponent
-Base.:^(a::Tracer, b::Tracer) = uniontracer(a, b)
-for T in (:Real, :Integer, :Rational)
-    @eval Base.:^(t::Tracer, ::$T) = t
-    @eval Base.:^(::$T, t::Tracer) = t
-end
-Base.:^(t::Tracer, ::Irrational{:ℯ}) = t
-Base.:^(::Irrational{:ℯ}, t::Tracer) = t
-
-## Precision operators create empty Tracer
-for fn in (:eps, :nextfloat, :floatmin, :floatmax, :maxintfloat, :typemax)
-    @eval Base.$fn(::Tracer) = EMPTY_TRACER
-end
-
-## Rounding with RoundingMode
-Base.round(t::Tracer, ::RoundingMode; kwargs...) = t
-
-## Random numbers
-rand(::AbstractRNG, ::SamplerType{Tracer}) = EMPTY_TRACER

--- a/src/overload_tracer.jl
+++ b/src/overload_tracer.jl
@@ -1,5 +1,9 @@
-for fn in ops_1_to_1
+for fn in union(ops_1_to_1_s, ops_1_to_1_f)
     @eval Base.$fn(t::Tracer) = t
+end
+
+for fn in ops_1_to_1_z
+    @eval Base.$fn(::Tracer) = EMPTY_TRACER
 end
 
 for fn in ops_1_to_2
@@ -20,11 +24,6 @@ for T in (:Real, :Integer, :Rational)
 end
 Base.:^(t::Tracer, ::Irrational{:ℯ}) = t
 Base.:^(::Irrational{:ℯ}, t::Tracer) = t
-
-## Precision operators create empty Tracer
-for fn in (:eps, :nextfloat, :floatmin, :floatmax, :maxintfloat, :typemax)
-    @eval Base.$fn(::Tracer) = EMPTY_TRACER
-end
 
 ## Rounding
 Base.round(t::Tracer, ::RoundingMode; kwargs...) = t

--- a/src/overload_tracer.jl
+++ b/src/overload_tracer.jl
@@ -1,0 +1,33 @@
+for fn in ops_1_to_1
+    @eval Base.$fn(t::Tracer) = t
+end
+
+for fn in ops_1_to_2
+    @eval Base.$fn(t::Tracer) = (t, t)
+end
+
+for fn in ops_2_to_1
+    @eval Base.$fn(a::Tracer, b::Tracer) = uniontracer(a, b)
+    @eval Base.$fn(t::Tracer, ::Number) = t
+    @eval Base.$fn(::Number, t::Tracer) = t
+end
+
+# Extra types required for exponent
+Base.:^(a::Tracer, b::Tracer) = uniontracer(a, b)
+for T in (:Real, :Integer, :Rational)
+    @eval Base.:^(t::Tracer, ::$T) = t
+    @eval Base.:^(::$T, t::Tracer) = t
+end
+Base.:^(t::Tracer, ::Irrational{:ℯ}) = t
+Base.:^(::Irrational{:ℯ}, t::Tracer) = t
+
+## Precision operators create empty Tracer
+for fn in (:eps, :nextfloat, :floatmin, :floatmax, :maxintfloat, :typemax)
+    @eval Base.$fn(::Tracer) = EMPTY_TRACER
+end
+
+## Rounding
+Base.round(t::Tracer, ::RoundingMode; kwargs...) = t
+
+## Random numbers
+rand(::AbstractRNG, ::SamplerType{Tracer}) = EMPTY_TRACER

--- a/src/overload_tracer.jl
+++ b/src/overload_tracer.jl
@@ -1,8 +1,8 @@
-for fn in union(ops_1_to_1_s, ops_1_to_1_f)
+for fn in union(ops_1_to_1_s, ops_1_to_1_f, ops_1_to_1_z)
     @eval Base.$fn(t::Tracer) = t
 end
 
-for fn in ops_1_to_1_z
+for fn in ops_1_to_1_const
     @eval Base.$fn(::Tracer) = EMPTY_TRACER
 end
 

--- a/test/order.jl
+++ b/test/order.jl
@@ -1,0 +1,155 @@
+using ForwardDiff: derivative, gradient, hessian
+using SparseConnectivityTracer
+using Test
+
+@enum Order zero_order = 0 first_order = 1 second_order = 2 no_order = 1000
+
+function parse_order(c::Char)
+    if c == 'z'
+        return zero_order
+    elseif c == 'f'
+        return first_order
+    elseif c == 's' || c == 'c'
+        return second_order
+    end
+end
+
+function parse_orders(code::Symbol)
+    str = string(code)
+    return Tuple(parse_order(str[i]) for i in eachindex(str))
+end
+
+@test parse_orders(:z) == (zero_order,)
+@test parse_orders(:fs) == (first_order, second_order)
+@test parse_orders(:sfc) == (second_order, first_order, second_order)
+
+## 1 to 1
+
+second_derivative(f, x) = derivative(_x -> derivative(f, _x), x)
+
+function classify_1_to_1(f, x; atol)
+    d1 = derivative(f, x)
+    d2 = second_derivative(f, x)
+    if abs(d1) <= atol && abs(d2) <= atol
+        return (zero_order,)
+    elseif abs(d1) > atol && abs(d2) <= atol
+        return (first_order,)
+    elseif abs(d1) > atol && abs(d2) > atol
+        return (second_order,)
+    end
+end
+
+function classify_1_to_1(f; atol=1e-5)
+    try
+        return classify_1_to_1(f, rand(); atol)
+    catch e
+        try
+            return classify_1_to_1(f, 1 + rand(); atol)
+        catch e
+            @warn "Classification failed" e
+            return (no_order,)
+        end
+    end
+end
+
+@testset verbose = true "1-to-1" begin
+    @testset "$code" for code in (:s, :f, :z)
+        assigned_order = parse_orders(code)
+        list = @eval SparseConnectivityTracer.$(Symbol("ops_1_to_1_$code"))
+        for f_symb in list
+            numerical_order = classify_1_to_1(eval(f_symb))
+            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+        end
+    end
+end;
+
+## 2 to 1
+
+function classify_2_to_1(f, x, y; atol)
+    g = gradient(Base.splat(f), [x, y])
+    H = hessian(Base.splat(f), [x, y])
+    first_arg = if abs(g[1]) <= atol && abs(H[1, 1]) <= atol
+        zero_order
+    elseif abs(g[1]) > atol && abs(H[1, 1]) <= atol
+        first_order
+    elseif abs(g[1]) > atol && abs(H[1, 1]) > atol
+        second_order
+    end
+    second_arg = if abs(g[2]) <= atol && abs(H[2, 2]) <= atol
+        zero_order
+    elseif abs(g[2]) > atol && abs(H[2, 2]) <= atol
+        first_order
+    elseif abs(g[2]) > atol && abs(H[2, 2]) > atol
+        second_order
+    end
+    cross = if abs(H[1, 2]) <= atol
+        zero_order
+    else
+        second_order
+    end
+    return (first_arg, second_arg, cross)
+end
+
+function classify_2_to_1(f; atol=1e-5)
+    try
+        return classify_2_to_1(f, rand(), rand(); atol)
+    catch e
+        @warn "Classification failed" e
+        return (no_order, no_order, no_order)
+    end
+end
+
+@testset verbose = true "2-to-1" begin
+    @testset "$code" for code in (
+        :ssc, :ssz, :sfc, :sfz, :fsc, :fsz, :ffc, :ffz, :szz, :zsz, :fzz, :zfz, :zzz
+    )
+        assigned_order = parse_orders(code)
+        list = @eval SparseConnectivityTracer.$(Symbol("ops_2_to_1_$code"))
+        for f_symb in list
+            numerical_order = classify_2_to_1(eval(f_symb))
+            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+        end
+    end
+end;
+
+## 1 to 2
+
+function classify_1_to_2(f, x; atol)
+    d1 = derivative(f, x)
+    d2 = second_derivative(f, x)
+    first_arg = if abs(d1[1]) <= atol && abs(d2[1]) <= atol
+        zero_order
+    elseif abs(d1[1]) > atol && abs(d2[1]) <= atol
+        first_order
+    elseif abs(d1[1]) > atol && abs(d2[1]) > atol
+        second_order
+    end
+    second_arg = if abs(d1[2]) <= atol && abs(d2[2]) <= atol
+        zero_order
+    elseif abs(d1[2]) > atol && abs(d2[2]) <= atol
+        first_order
+    elseif abs(d1[2]) > atol && abs(d2[2]) > atol
+        second_order
+    end
+    return (first_arg, second_arg)
+end
+
+function classify_1_to_2(f; atol=1e-5)
+    try
+        return classify_1_to_1(f, rand(); atol)
+    catch e
+        @warn "Classification failed" e
+        return (no_order, no_order)
+    end
+end
+
+@testset verbose = true "1-to-2" begin
+    @testset "$code" for code in (:sf, :sz, :fs, :ff, :fz)
+        assigned_order = parse_orders(code)
+        list = @eval SparseConnectivityTracer.$(Symbol("ops_1_to_2_$code"))
+        for f_symb in list
+            numerical_order = classify_1_to_2(eval(f_symb))
+            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+        end
+    end
+end;

--- a/test/order.jl
+++ b/test/order.jl
@@ -40,14 +40,17 @@ function classify_1_to_1(f, x; atol)
         return (zero_order,)
     elseif abs(d1) > atol && abs(d2) <= atol
         return (first_order,)
-    elseif abs(d1) > atol && abs(d2) > atol
+    elseif abs(d2) > atol
         return (second_order,)
+    else
+        @warn "Weird behavior" f x d1 d2
+        return (no_order,)
     end
 end
 
-function classify_1_to_1(f; atol=1e-5)
+function classify_1_to_1(f; atol=1e-5, trials=100)
     try
-        return classify_1_to_1(f, random_input(f); atol)
+        return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
         @warn "Classification failed" e
         return (no_order,)
@@ -74,27 +77,39 @@ function classify_2_to_1(f, x, y; atol)
         zero_order
     elseif abs(g[1]) > atol && abs(H[1, 1]) <= atol
         first_order
-    elseif abs(g[1]) > atol && abs(H[1, 1]) > atol
+    elseif abs(H[1, 1]) > atol
         second_order
+    else
+        @warn "Weird behavior" f x g H
+        no_order
     end
     second_arg = if abs(g[2]) <= atol && abs(H[2, 2]) <= atol
         zero_order
     elseif abs(g[2]) > atol && abs(H[2, 2]) <= atol
         first_order
-    elseif abs(g[2]) > atol && abs(H[2, 2]) > atol
+    elseif abs(H[2, 2]) > atol
         second_order
+    else
+        @warn "Weird behavior" f x g H
+        no_order
     end
     cross = if abs(H[1, 2]) <= atol
         zero_order
-    else
+    elseif abs(H[1, 2]) > atol
         second_order
+    else
+        @warn "Weird behavior" f x g H
+        no_order
     end
     return (first_arg, second_arg, cross)
 end
 
-function classify_2_to_1(f; atol=1e-5)
+function classify_2_to_1(f; atol=1e-5, trials=100)
     try
-        return classify_2_to_1(f, random_first_input(f), random_second_input(f); atol)
+        return maximum(
+            classify_2_to_1(f, random_first_input(f), random_second_input(f); atol) for
+            _ in 1:trials
+        )
     catch e
         @warn "Classification failed" e
         return (no_order, no_order, no_order)
@@ -123,22 +138,28 @@ function classify_1_to_2(f, x; atol)
         zero_order
     elseif abs(d1[1]) > atol && abs(d2[1]) <= atol
         first_order
-    elseif abs(d1[1]) > atol && abs(d2[1]) > atol
+    elseif abs(d2[1]) > atol
         second_order
+    else
+        @warn "Weird behavior" f x d1 d2
+        no_order
     end
     second_arg = if abs(d1[2]) <= atol && abs(d2[2]) <= atol
         zero_order
     elseif abs(d1[2]) > atol && abs(d2[2]) <= atol
         first_order
-    elseif abs(d1[2]) > atol && abs(d2[2]) > atol
+    elseif abs(d2[2]) > atol
         second_order
+    else
+        @warn "Weird behavior" f x d1 d2
+        no_order
     end
     return (first_arg, second_arg)
 end
 
-function classify_1_to_2(f; atol=1e-5)
+function classify_1_to_2(f; atol=1e-5, trials=100)
     try
-        return classify_1_to_1(f, random_input(f); atol)
+        return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
         @warn "Classification failed" e
         return (no_order, no_order)

--- a/test/order.jl
+++ b/test/order.jl
@@ -1,69 +1,115 @@
 using ForwardDiff: derivative, gradient, hessian
-using SparseConnectivityTracer
+using SparseConnectivityTracer:
+    ops_1_to_1,
+    ops_1_to_1_s,
+    ops_1_to_1_f,
+    ops_1_to_1_z,
+    ops_1_to_1_const,
+    ops_2_to_1,
+    ops_2_to_1_ssc,
+    ops_2_to_1_ssz,
+    ops_2_to_1_sfc,
+    ops_2_to_1_sfz,
+    ops_2_to_1_fsc,
+    ops_2_to_1_fsz,
+    ops_2_to_1_ffc,
+    ops_2_to_1_ffz,
+    ops_2_to_1_szz,
+    ops_2_to_1_zsz,
+    ops_2_to_1_fzz,
+    ops_2_to_1_zfz,
+    ops_2_to_1_zzz,
+    ops_1_to_2,
+    ops_1_to_2_ss,
+    ops_1_to_2_sf,
+    ops_1_to_2_fs,
+    ops_1_to_2_ff,
+    ops_1_to_2_sz,
+    ops_1_to_2_zs,
+    ops_1_to_2_fz,
+    ops_1_to_2_zf,
+    ops_1_to_2_zz
 using Test
 
+DEFAULT_ATOL = 1e-8
+isapproxzero(x; atol=DEFAULT_ATOL) = abs(x) <= atol
+
 random_input(f) = rand()
+random_input(::Union{typeof(acosh),typeof(acoth),typeof(acsc),typeof(asec)}) = 1 + rand()
+
 random_first_input(f) = random_input(f)
 random_second_input(f) = random_input(f)
 
-random_input(::Union{typeof(acosh),typeof(acoth),typeof(acsc),typeof(asec)}) = 1 + rand()
+second_derivative(f, x) = derivative(_x -> derivative(f, _x), x)
 
-@enum Order zero_order = 0 first_order = 1 second_order = 2 no_order = 1000
+sym2fn(op::Symbol) = @eval Base.$op
 
-function parse_order(c::Char)
-    if c == 'z'
-        return zero_order
-    elseif c == 'f'
-        return first_order
-    elseif c == 's' || c == 'c'
-        return second_order
+# Use enum as return type
+@enum Order begin
+    zero_order   = 0
+    first_order  = 1
+    second_order = 2
+    error_order  = -1
+end
+
+function differentiability(∂f∂x, ∂²f∂x²; atol=DEFAULT_ATOL)
+    is_∂f∂x_zero   = isapproxzero(∂f∂x; atol)
+    is_∂²f∂x²_zero = isapproxzero(∂²f∂x²; atol)
+
+    if !is_∂f∂x_zero
+        if !is_∂²f∂x²_zero
+            return second_order
+        else
+            return first_order
+        end
+    else # is_∂f∂x_zero
+        if is_∂²f∂x²_zero
+            return zero_order
+        else
+            return error_order
+        end
     end
 end
-
-function parse_orders(code::Symbol)
-    str = string(code)
-    return Tuple(parse_order(str[i]) for i in eachindex(str))
-end
-
-@test parse_orders(:z) == (zero_order,)
-@test parse_orders(:fs) == (first_order, second_order)
-@test parse_orders(:sfc) == (second_order, first_order, second_order)
 
 ## 1 to 1
 
-second_derivative(f, x) = derivative(_x -> derivative(f, _x), x)
+function classify_1_to_1(f, x; atol=DEFAULT_ATOL)
+    ∂f∂x = derivative(f, x)
+    ∂²f∂x² = second_derivative(f, x)
 
-function classify_1_to_1(f, x; atol)
-    d1 = derivative(f, x)
-    d2 = second_derivative(f, x)
-    if abs(d1) <= atol && abs(d2) <= atol
-        return (zero_order,)
-    elseif abs(d1) > atol && abs(d2) <= atol
-        return (first_order,)
-    elseif abs(d2) > atol
-        return (second_order,)
-    else
-        @warn "Weird behavior" f x d1 d2
-        return (no_order,)
-    end
+    order = differentiability(∂f∂x, ∂²f∂x²; atol)
+    order == error_order && @warn "Weird behavior" f x ∂f∂x ∂²f∂x²
+    return order
 end
 
-function classify_1_to_1(f; atol=1e-5, trials=100)
+classify_1_to_1(op::Symbol; kwargs...) = classify_1_to_1(sym2fn(op); kwargs...)
+function classify_1_to_1(f::Function; atol=DEFAULT_ATOL, trials=100)
     try
         return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
         @warn "Classification failed" e
-        return (no_order,)
+        return error_order
     end
 end
 
-@testset verbose = true "1-to-1" begin
-    @testset "$code" for code in (:s, :f, :z)
-        assigned_order = parse_orders(code)
-        list = @eval SparseConnectivityTracer.$(Symbol("ops_1_to_1_$code"))
-        for f_symb in list
-            numerical_order = classify_1_to_1(eval(f_symb))
-            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+const TEST_1_TO_1 = (
+    ("Second order", ops_1_to_1_s, second_order),
+    ("First order", ops_1_to_1_f, first_order),
+    ("Zero order", ops_1_to_1_z, zero_order),
+    ("Constant", ops_1_to_1_const, zero_order),
+)
+@testset verbose = true "1 to 1" begin
+    @testset "All operators covered" begin
+        all_ops = union([ops for (name, ops, ref_order) in TEST_1_TO_1]...)
+        @test Set(all_ops) == Set(ops_1_to_1)
+    end
+    for (name, ops, ref_order) in TEST_1_TO_1
+        @testset "$name" begin
+            for op in ops
+                @testset "$op" begin
+                    @test classify_1_to_1(op) == ref_order
+                end
+            end
         end
     end
 end;
@@ -73,37 +119,24 @@ end;
 function classify_2_to_1(f, x, y; atol)
     g = gradient(Base.splat(f), [x, y])
     H = hessian(Base.splat(f), [x, y])
-    first_arg = if abs(g[1]) <= atol && abs(H[1, 1]) <= atol
-        zero_order
-    elseif abs(g[1]) > atol && abs(H[1, 1]) <= atol
-        first_order
-    elseif abs(H[1, 1]) > atol
-        second_order
-    else
-        @warn "Weird behavior" f x g H
-        no_order
-    end
-    second_arg = if abs(g[2]) <= atol && abs(H[2, 2]) <= atol
-        zero_order
-    elseif abs(g[2]) > atol && abs(H[2, 2]) <= atol
-        first_order
-    elseif abs(H[2, 2]) > atol
-        second_order
-    else
-        @warn "Weird behavior" f x g H
-        no_order
-    end
-    cross = if abs(H[1, 2]) <= atol
-        zero_order
-    elseif abs(H[1, 2]) > atol
-        second_order
-    else
-        @warn "Weird behavior" f x g H
-        no_order
-    end
+
+    ∂f∂x    = g[1]
+    ∂f∂y    = g[2]
+    ∂²f∂x²  = H[1, 1]
+    ∂²f∂y²  = H[2, 2]
+    ∂²f∂x∂y = H[1, 2]
+
+    first_arg = differentiability(∂f∂x, ∂²f∂x²; atol)
+    first_arg == error_order && @warn "Weird behavior on argument x" f x y ∂f∂x ∂²f∂x²
+
+    second_arg = differentiability(∂f∂y, ∂²f∂y²; atol)
+    second_arg == error_order && @warn "Weird behavior on argument y" f x y ∂f∂y ∂²f∂y²
+
+    cross = isapproxzero(∂²f∂x∂y; atol) ? zero_order : second_order
     return (first_arg, second_arg, cross)
 end
 
+classify_2_to_1(op::Symbol; kwargs...) = classify_2_to_1(sym2fn(op); kwargs...)
 function classify_2_to_1(f; atol=1e-5, trials=100)
     try
         return maximum(
@@ -112,19 +145,37 @@ function classify_2_to_1(f; atol=1e-5, trials=100)
         )
     catch e
         @warn "Classification failed" e
-        return (no_order, no_order, no_order)
+        return (error_order, error_order, error_order)
     end
 end
 
-@testset verbose = true "2-to-1" begin
-    @testset "$code" for code in (
-        :ssc, :ssz, :sfc, :sfz, :fsc, :fsz, :ffc, :ffz, :szz, :zsz, :fzz, :zfz, :zzz
-    )
-        assigned_order = parse_orders(code)
-        list = @eval SparseConnectivityTracer.$(Symbol("ops_2_to_1_$code"))
-        for f_symb in list
-            numerical_order = classify_2_to_1(eval(f_symb))
-            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+const TEST_2_TO_1 = (
+    ("ssc", ops_2_to_1_ssc, (second_order, second_order, second_order)),
+    ("ssz", ops_2_to_1_ssz, (second_order, second_order, zero_order)),
+    ("sfc", ops_2_to_1_sfc, (second_order, first_order, second_order)),
+    ("sfz", ops_2_to_1_sfz, (second_order, first_order, zero_order)),
+    ("fsc", ops_2_to_1_fsc, (first_order, second_order, second_order)),
+    ("fsz", ops_2_to_1_fsz, (first_order, second_order, zero_order)),
+    ("ffc", ops_2_to_1_ffc, (first_order, first_order, second_order)),
+    ("ffz", ops_2_to_1_ffz, (first_order, first_order, zero_order)),
+    ("szz", ops_2_to_1_szz, (second_order, zero_order, zero_order)),
+    ("zsz", ops_2_to_1_zsz, (zero_order, second_order, zero_order)),
+    ("fzz", ops_2_to_1_fzz, (first_order, zero_order, zero_order)),
+    ("zfz", ops_2_to_1_zfz, (zero_order, second_order, zero_order)),
+    ("zzz", ops_2_to_1_zzz, (zero_order, zero_order, zero_order)),
+)
+@testset verbose = true "2 to 1" begin
+    @testset "All operators covered" begin
+        all_ops = union([ops for (name, ops, ref_order) in TEST_2_TO_1]...)
+        @test Set(all_ops) == Set(ops_2_to_1)
+    end
+    for (name, ops, ref_order) in TEST_2_TO_1
+        @testset "$name" begin
+            for op in ops
+                @testset "$op" begin
+                    @test classify_2_to_1(op) == ref_order
+                end
+            end
         end
     end
 end;
@@ -134,45 +185,52 @@ end;
 function classify_1_to_2(f, x; atol)
     d1 = derivative(f, x)
     d2 = second_derivative(f, x)
-    first_arg = if abs(d1[1]) <= atol && abs(d2[1]) <= atol
-        zero_order
-    elseif abs(d1[1]) > atol && abs(d2[1]) <= atol
-        first_order
-    elseif abs(d2[1]) > atol
-        second_order
-    else
-        @warn "Weird behavior" f x d1 d2
-        no_order
-    end
-    second_arg = if abs(d1[2]) <= atol && abs(d2[2]) <= atol
-        zero_order
-    elseif abs(d1[2]) > atol && abs(d2[2]) <= atol
-        first_order
-    elseif abs(d2[2]) > atol
-        second_order
-    else
-        @warn "Weird behavior" f x d1 d2
-        no_order
-    end
+    ∂f₁∂x = d1[1]
+    ∂f₂∂x = d1[2]
+    ∂²f₁∂x² = d2[1]
+    ∂²f₂∂x² = d2[2]
+
+    first_out = differentiability(∂f₁∂x, ∂²f₁∂x²; atol)
+    first_out == error_order && @warn "Weird behavior w.r.t. first output" f x ∂f₁∂x ∂²f₁∂x²
+    first_out = differentiability(∂f₂∂x, ∂²f₂∂x²; atol)
+    first_out == error_order &&
+        @warn "Weird behavior w.r.t. second output" f x ∂f₂∂x ∂²f₂∂x²
     return (first_arg, second_arg)
 end
 
+classify_1_to_2(op::Symbol; kwargs...) = classify_1_to_2(sym2fn(op); kwargs...)
 function classify_1_to_2(f; atol=1e-5, trials=100)
     try
         return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
         @warn "Classification failed" e
-        return (no_order, no_order)
+        return (error_order, error_order)
     end
 end
 
-@testset verbose = true "1-to-2" begin
-    @testset "$code" for code in (:sf, :sz, :fs, :ff, :fz)
-        assigned_order = parse_orders(code)
-        list = @eval SparseConnectivityTracer.$(Symbol("ops_1_to_2_$code"))
-        for f_symb in list
-            numerical_order = classify_1_to_2(eval(f_symb))
-            @test (f_symb, numerical_order) <= (f_symb, assigned_order)
+const TEST_1_TO_2 = (
+    ("ss", ops_1_to_2_ss, (second_order, second_order)),
+    ("sf", ops_1_to_2_sf, (second_order, first_order)),
+    ("fs", ops_1_to_2_fs, (first_order, second_order)),
+    ("ff", ops_1_to_2_ff, (first_order, first_order)),
+    ("sz", ops_1_to_2_sz, (second_order, zero_order)),
+    ("zs", ops_1_to_2_zs, (zero_order, second_order)),
+    ("fz", ops_1_to_2_fz, (first_order, zero_order)),
+    ("zf", ops_1_to_2_zf, (zero_order, second_order)),
+    ("zz", ops_1_to_2_zz, (zero_order, zero_order)),
+)
+@testset verbose = true "1 to 2" begin
+    @testset "All operators covered" begin
+        all_ops = union([ops for (name, ops, ref_order) in TEST_1_TO_2]...)
+        @test Set(all_ops) == Set(ops_1_to_2)
+    end
+    for (name, ops, ref_order) in TEST_1_TO_2
+        @testset "$name" begin
+            for op in ops
+                @testset "$op" begin
+                    @test classify_1_to_2(op) == ref_order
+                end
+            end
         end
     end
 end;

--- a/test/order.jl
+++ b/test/order.jl
@@ -2,6 +2,12 @@ using ForwardDiff: derivative, gradient, hessian
 using SparseConnectivityTracer
 using Test
 
+random_input(f) = rand()
+random_first_input(f) = random_input(f)
+random_second_input(f) = random_input(f)
+
+random_input(::Union{typeof(acosh),typeof(acoth),typeof(acsc),typeof(asec)}) = 1 + rand()
+
 @enum Order zero_order = 0 first_order = 1 second_order = 2 no_order = 1000
 
 function parse_order(c::Char)
@@ -41,14 +47,10 @@ end
 
 function classify_1_to_1(f; atol=1e-5)
     try
-        return classify_1_to_1(f, rand(); atol)
+        return classify_1_to_1(f, random_input(f); atol)
     catch e
-        try
-            return classify_1_to_1(f, 1 + rand(); atol)
-        catch e
-            @warn "Classification failed" e
-            return (no_order,)
-        end
+        @warn "Classification failed" e
+        return (no_order,)
     end
 end
 
@@ -92,7 +94,7 @@ end
 
 function classify_2_to_1(f; atol=1e-5)
     try
-        return classify_2_to_1(f, rand(), rand(); atol)
+        return classify_2_to_1(f, random_first_input(f), random_second_input(f); atol)
     catch e
         @warn "Classification failed" e
         return (no_order, no_order, no_order)
@@ -136,7 +138,7 @@ end
 
 function classify_1_to_2(f; atol=1e-5)
     try
-        return classify_1_to_1(f, rand(); atol)
+        return classify_1_to_1(f, random_input(f); atol)
     catch e
         @warn "Classification failed" e
         return (no_order, no_order)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,8 +36,8 @@ DocMeta.setdocmeta!(
     @testset "JET tests" begin
         JET.test_package(SparseConnectivityTracer; target_defined_modules=true)
     end
-    @testset verbose = true "Order classification" begin
-        include("order.jl")
+    @testset verbose = true "Classification of operators by diff'ability" begin
+        include("test_differentiability.jl")
     end
     @testset "Connectivity" begin
         x = rand(3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,9 @@ DocMeta.setdocmeta!(
     @testset "JET tests" begin
         JET.test_package(SparseConnectivityTracer; target_defined_modules=true)
     end
-
+    @testset verbose = true "Order classification" begin
+        include("order.jl")
+    end
     @testset "Connectivity" begin
         x = rand(3)
         xt = trace_input(x)

--- a/test/test_differentiability.jl
+++ b/test/test_differentiability.jl
@@ -71,7 +71,7 @@ function differentiability(∂f∂x, ∂²f∂x²; atol=DEFAULT_ATOL)
     end
 end
 
-## 1 to 1
+## 1-to-1
 
 function classify_1_to_1(f, x; atol=DEFAULT_ATOL)
     ∂f∂x = derivative(f, x)
@@ -82,12 +82,12 @@ function classify_1_to_1(f, x; atol=DEFAULT_ATOL)
     return order
 end
 
-classify_1_to_1(op::Symbol; kwargs...) = classify_1_to_1(sym2fn(op); kwargs...)
-function classify_1_to_1(f::Function; atol=DEFAULT_ATOL, trials=100)
+function classify_1_to_1(op::Symbol; atol=DEFAULT_ATOL, trials=100)
+    f = sym2fn(op)
     try
         return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
-        @warn "Classification failed" e
+        @warn "Classification of 1-to-1 operator $op failed" e
         return error_order
     end
 end
@@ -98,7 +98,7 @@ const TEST_1_TO_1 = (
     ("Zero order", ops_1_to_1_z, zero_order),
     ("Constant", ops_1_to_1_const, zero_order),
 )
-@testset verbose = true "1 to 1" begin
+@testset verbose = true "1-to-1" begin
     @testset "All operators covered" begin
         all_ops = union([ops for (name, ops, ref_order) in TEST_1_TO_1]...)
         @test Set(all_ops) == Set(ops_1_to_1)
@@ -114,7 +114,7 @@ const TEST_1_TO_1 = (
     end
 end;
 
-## 2 to 1
+## 2-to-1
 
 function classify_2_to_1(f, x, y; atol)
     g = gradient(Base.splat(f), [x, y])
@@ -137,14 +137,15 @@ function classify_2_to_1(f, x, y; atol)
 end
 
 classify_2_to_1(op::Symbol; kwargs...) = classify_2_to_1(sym2fn(op); kwargs...)
-function classify_2_to_1(f; atol=1e-5, trials=100)
+function classify_2_to_1(op::Symbol; atol=1e-5, trials=100)
+    f = sym2fn(op)
     try
         return maximum(
             classify_2_to_1(f, random_first_input(f), random_second_input(f); atol) for
             _ in 1:trials
         )
     catch e
-        @warn "Classification failed" e
+        @warn "Classification of 2-to-1 operator `$op` failed" e
         return (error_order, error_order, error_order)
     end
 end
@@ -164,7 +165,7 @@ const TEST_2_TO_1 = (
     ("zfz", ops_2_to_1_zfz, (zero_order, second_order, zero_order)),
     ("zzz", ops_2_to_1_zzz, (zero_order, zero_order, zero_order)),
 )
-@testset verbose = true "2 to 1" begin
+@testset verbose = true "2-to-1" begin
     @testset "All operators covered" begin
         all_ops = union([ops for (name, ops, ref_order) in TEST_2_TO_1]...)
         @test Set(all_ops) == Set(ops_2_to_1)
@@ -180,7 +181,7 @@ const TEST_2_TO_1 = (
     end
 end;
 
-## 1 to 2
+## 1-to-2
 
 function classify_1_to_2(f, x; atol)
     d1 = derivative(f, x)
@@ -198,12 +199,12 @@ function classify_1_to_2(f, x; atol)
     return (first_arg, second_arg)
 end
 
-classify_1_to_2(op::Symbol; kwargs...) = classify_1_to_2(sym2fn(op); kwargs...)
-function classify_1_to_2(f; atol=1e-5, trials=100)
+function classify_1_to_2(op::Symbol; atol=1e-5, trials=100)
+    f = sym2fn(op)
     try
         return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
     catch e
-        @warn "Classification failed" e
+        @warn "Classification of 1-to-2 operator `$op` failed" e
         return (error_order, error_order)
     end
 end
@@ -219,7 +220,7 @@ const TEST_1_TO_2 = (
     ("zf", ops_1_to_2_zf, (zero_order, second_order)),
     ("zz", ops_1_to_2_zz, (zero_order, zero_order)),
 )
-@testset verbose = true "1 to 2" begin
+@testset verbose = true "1-to-2" begin
     @testset "All operators covered" begin
         all_ops = union([ops for (name, ops, ref_order) in TEST_1_TO_2]...)
         @test Set(all_ops) == Set(ops_1_to_2)


### PR DESCRIPTION
Automatically classify `1-to-1`, `2-to-1` and `1-to-2` operators based on differentiation order, by comparing with ForwardDiff.

Gives you a nice summary

![image](https://github.com/adrhill/SparseConnectivityTracer.jl/assets/22795598/3cde8eee-4d5c-4685-9bfe-1367581a319a)

and precise errors

![image](https://github.com/adrhill/SparseConnectivityTracer.jl/assets/22795598/cb1477ab-aa5b-4227-b09b-c0335c714eeb)
