### PR TITLE
Remove AbstractIndexSet typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ julia> jacobian_pattern(layer, x)
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠛⢿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣷⣄⎦
 ```
 
-The type of index set `T<:AbstractSet{<:Integer}` that is internally used to keep track of connectivity can be specified via `jacobian_pattern(f, x, T)`, defaulting to `BitSet`. 
+The type of index set `T` that is internally used to keep track of connectivity can be specified via `jacobian_pattern(f, x, T)`, defaulting to `BitSet`. 
 For high-dimensional functions, `Set{UInt64}` can be more efficient .
 
 ### Hessian

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ julia> jacobian_pattern(layer, x)
 ⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⢿⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠛⢿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣷⣄⎦
 ```
 
-The type of index set `T` that is internally used to keep track of connectivity can be specified via `jacobian_pattern(f, x, T)`, defaulting to `BitSet`. 
+The type of index set `S` that is internally used to keep track of connectivity can be specified via `jacobian_pattern(f, x, S)`, defaulting to `BitSet`. 
 For high-dimensional functions, `Set{UInt64}` can be more efficient .
 
 ### Hessian

--- a/src/adtypes.jl
+++ b/src/adtypes.jl
@@ -28,24 +28,18 @@ julia> ADTypes.hessian_sparsity(f, rand(4), TracerSparsityDetector())
  ⋅  ⋅  ⋅  1
 ```
 """
-struct TracerSparsityDetector{S<:AbstractIndexSet} <: ADTypes.AbstractSparsityDetector end
-TracerSparsityDetector(::Type{S}) where {S<:AbstractIndexSet} = TracerSparsityDetector{S}()
+struct TracerSparsityDetector{S} <: ADTypes.AbstractSparsityDetector end
+TracerSparsityDetector(::Type{S}) where {S} = TracerSparsityDetector{S}()
 TracerSparsityDetector() = TracerSparsityDetector(BitSet)
 
-function ADTypes.jacobian_sparsity(
-    f, x, ::TracerSparsityDetector{S}
-) where {S<:AbstractIndexSet}
+function ADTypes.jacobian_sparsity(f, x, ::TracerSparsityDetector{S}) where {S}
     return jacobian_pattern(f, x, S)
 end
 
-function ADTypes.jacobian_sparsity(
-    f!, y, x, ::TracerSparsityDetector{S}
-) where {S<:AbstractIndexSet}
+function ADTypes.jacobian_sparsity(f!, y, x, ::TracerSparsityDetector{S}) where {S}
     return jacobian_pattern(f!, y, x, S)
 end
 
-function ADTypes.hessian_sparsity(
-    f, x, ::TracerSparsityDetector{S}
-) where {S<:AbstractIndexSet}
+function ADTypes.hessian_sparsity(f, x, ::TracerSparsityDetector{S}) where {S}
     return hessian_pattern(f, x, S)
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -25,7 +25,6 @@ for TT in (:JacobianTracer, :ConnectivityTracer, :HessianTracer)
     @eval Base.similar(::Array{T}, m::Int) where {T<:$TT}          = zeros(T, m)
     @eval Base.similar(::Array{T}, dims::Dims{N}) where {N,T<:$TT} = zeros(T, dims)
 
-    @eval Base.similar(
-        ::Array, ::Type{$TT{S}}, dims::Dims{N}
-    ) where {N,S<:AbstractIndexSet} = zeros($TT{S}, dims)
+    @eval Base.similar(::Array, ::Type{$TT{S}}, dims::Dims{N}) where {N,S} =
+        zeros($TT{S}, dims)
 end

--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -24,7 +24,7 @@ end
 Enumerates inputs `x` and primal outputs `y = f(x)` and returns sparse matrix `C` of size `(m, n)`
 where `C[i, j]` is true if the compute graph connects the `i`-th entry in `y` to the `j`-th entry in `x`.
 
-The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `S` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 
@@ -50,7 +50,7 @@ connectivity_pattern(f, x, settype::Type{S}=DEFAULT_SET_TYPE) where {S} =
 Enumerates inputs `x` and primal outputs `y` after `f!(y, x)` and returns sparse matrix `C` of size `(m, n)`
 where `C[i, j]` is true if the compute graph connects the `i`-th entry in `y` to the `j`-th entry in `x`.
 
-The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `S` can be specified as an optional argument and defaults to `BitSet`.
 """
 function connectivity_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, ConnectivityTracer{S}, x)
@@ -62,7 +62,7 @@ end
 
 Compute the sparsity pattern of the Jacobian of `y = f(x)`.
 
-The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `S` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 
@@ -88,7 +88,7 @@ end
 
 Compute the sparsity pattern of the Jacobian of `f!(y, x)`.
 
-The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `S` can be specified as an optional argument and defaults to `BitSet`.
 """
 function jacobian_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, JacobianTracer{S}, x)
@@ -100,7 +100,7 @@ end
 
 Computes the sparsity pattern of the Hessian of a scalar function `y = f(x)`.
 
-The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `S` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 

--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -40,7 +40,7 @@ julia> connectivity_pattern(f, x)
  ⋅  ⋅  1
 ```
 """
-connectivity_pattern(f, x, settype::Type{S}=DEFAULT_SET_TYPE) where {S<:AbstractIndexSet} =
+connectivity_pattern(f, x, settype::Type{S}=DEFAULT_SET_TYPE) where {S} =
     pattern(f, ConnectivityTracer{S}, x)
 
 """
@@ -52,9 +52,7 @@ where `C[i, j]` is true if the compute graph connects the `i`-th entry in `y` to
 
 The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
 """
-function connectivity_pattern(
-    f!, y, x, ::Type{S}=DEFAULT_SET_TYPE
-) where {S<:AbstractIndexSet}
+function connectivity_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, ConnectivityTracer{S}, x)
 end
 
@@ -80,7 +78,7 @@ julia> jacobian_pattern(f, x)
  ⋅  ⋅  ⋅
 ```
 """
-function jacobian_pattern(f, x, ::Type{S}=DEFAULT_SET_TYPE) where {S<:AbstractIndexSet}
+function jacobian_pattern(f, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f, JacobianTracer{S}, x)
 end
 
@@ -92,7 +90,7 @@ Compute the sparsity pattern of the Jacobian of `f!(y, x)`.
 
 The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
 """
-function jacobian_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S<:AbstractIndexSet}
+function jacobian_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, JacobianTracer{S}, x)
 end
 
@@ -130,7 +128,7 @@ julia> hessian_pattern(g, x)
  ⋅  1  ⋅  ⋅  1
 ```
 """
-function hessian_pattern(f, x, ::Type{S}=DEFAULT_SET_TYPE) where {S<:AbstractIndexSet}
+function hessian_pattern(f, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f, HessianTracer{S}, x)
 end
 
@@ -176,7 +174,7 @@ end
 
 function _pattern_to_sparsemat(
     xt::AbstractArray{HessianTracer{S}}, yt::AbstractArray{HessianTracer{S}}
-) where {S<:AbstractIndexSet}
+) where {S}
     length(yt) != 1 && error("pattern(f, HessianTracer, x) expects scalar output y=f(x).")
     y = only(yt)
 

--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -24,7 +24,7 @@ end
 Enumerates inputs `x` and primal outputs `y = f(x)` and returns sparse matrix `C` of size `(m, n)`
 where `C[i, j]` is true if the compute graph connects the `i`-th entry in `y` to the `j`-th entry in `x`.
 
-The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 
@@ -50,7 +50,7 @@ connectivity_pattern(f, x, settype::Type{S}=DEFAULT_SET_TYPE) where {S} =
 Enumerates inputs `x` and primal outputs `y` after `f!(y, x)` and returns sparse matrix `C` of size `(m, n)`
 where `C[i, j]` is true if the compute graph connects the `i`-th entry in `y` to the `j`-th entry in `x`.
 
-The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
 """
 function connectivity_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, ConnectivityTracer{S}, x)
@@ -62,7 +62,7 @@ end
 
 Compute the sparsity pattern of the Jacobian of `y = f(x)`.
 
-The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 
@@ -88,7 +88,7 @@ end
 
 Compute the sparsity pattern of the Jacobian of `f!(y, x)`.
 
-The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
 """
 function jacobian_pattern(f!, y, x, ::Type{S}=DEFAULT_SET_TYPE) where {S}
     return pattern(f!, y, JacobianTracer{S}, x)
@@ -100,7 +100,7 @@ end
 
 Computes the sparsity pattern of the Hessian of a scalar function `y = f(x)`.
 
-The type of index set `T<:AbstractSet{<:Integer}` can be specified as an optional argument and defaults to `BitSet`.
+The type of index set `T` can be specified as an optional argument and defaults to `BitSet`.
 
 ## Example
 

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -1,7 +1,5 @@
 abstract type AbstractTracer <: Number end
 
-const AbstractIndexSet = AbstractSet{<:Integer}
-
 # Convenience constructor for empty tracers
 empty(tracer::T) where {T<:AbstractTracer} = empty(T)
 
@@ -13,19 +11,24 @@ empty(tracer::T) where {T<:AbstractTracer} = empty(T)
     ConnectivityTracer{S}(indexset) <: Number
 
 Number type keeping track of input indices of previous computations.
-The provided index set type `S` has to be an `AbstractSet{<:Integer}`, e.g. `BitSet` or `Set{UInt64}`.
+The provided index set type `S` has to satisfy the following conditions:
+
+- it is an iterable with `<:Integer` element type
+- it implements methods `union` and `push!`
+
+Subtypes of `AbstractSet{<:Integer}` are a natural choice, like `BitSet` or `Set{UInt64}`.
 
 For a higher-level interface, refer to [`connectivity_pattern`](@ref).
 """
-struct ConnectivityTracer{S<:AbstractIndexSet} <: AbstractTracer
+struct ConnectivityTracer{S} <: AbstractTracer
     inputs::S # indices of connected, enumerated inputs
 end
 
-function Base.show(io::IO, t::ConnectivityTracer{S}) where {S<:AbstractIndexSet}
+function Base.show(io::IO, t::ConnectivityTracer{S}) where {S}
     return Base.show_delim_array(io, inputs(t), "ConnectivityTracer{$S}(", ',', ')', true)
 end
 
-empty(::Type{ConnectivityTracer{S}}) where {S<:AbstractIndexSet} = ConnectivityTracer(S())
+empty(::Type{ConnectivityTracer{S}}) where {S} = ConnectivityTracer(S())
 
 # Performance can be gained by not re-allocating empty tracers
 const EMPTY_CONNECTIVITY_TRACER_BITSET     = ConnectivityTracer(BitSet())
@@ -44,13 +47,11 @@ empty(::Type{ConnectivityTracer{Set{UInt64}}}) = EMPTY_CONNECTIVITY_TRACER_SET_U
 # Generic code expecting "regular" numbers `x` will sometimes convert them 
 # by calling `T(x)` (instead of `convert(T, x)`), where `T` can be `ConnectivityTracer`.
 # When this happens, we create a new empty tracer with no input pattern.
-ConnectivityTracer{S}(::Number) where {S<:AbstractIndexSet} = empty(ConnectivityTracer{S})
+ConnectivityTracer{S}(::Number) where {S} = empty(ConnectivityTracer{S})
 ConnectivityTracer(t::ConnectivityTracer) = t
 
 ## Unions of tracers
-function uniontracer(
-    a::ConnectivityTracer{S}, b::ConnectivityTracer{S}
-) where {S<:AbstractIndexSet}
+function uniontracer(a::ConnectivityTracer{S}, b::ConnectivityTracer{S}) where {S}
     return ConnectivityTracer(union(a.inputs, b.inputs))
 end
 
@@ -66,15 +67,15 @@ The provided index set type `S` has to be an `AbstractSet{<:Integer}`, e.g. `Bit
 
 For a higher-level interface, refer to [`jacobian_pattern`](@ref).
 """
-struct JacobianTracer{S<:AbstractIndexSet} <: AbstractTracer
+struct JacobianTracer{S} <: AbstractTracer
     inputs::S
 end
 
-function Base.show(io::IO, t::JacobianTracer{S}) where {S<:AbstractIndexSet}
+function Base.show(io::IO, t::JacobianTracer{S}) where {S}
     return Base.show_delim_array(io, inputs(t), "JacobianTracer{$S}(", ',', ')', true)
 end
 
-empty(::Type{JacobianTracer{S}}) where {S<:AbstractIndexSet} = JacobianTracer(S())
+empty(::Type{JacobianTracer{S}}) where {S} = JacobianTracer(S())
 
 # Performance can be gained by not re-allocating empty tracers
 const EMPTY_JACOBIAN_TRACER_BITSET     = JacobianTracer(BitSet())
@@ -89,11 +90,11 @@ empty(::Type{JacobianTracer{Set{UInt16}}}) = EMPTY_JACOBIAN_TRACER_SET_UINT16
 empty(::Type{JacobianTracer{Set{UInt32}}}) = EMPTY_JACOBIAN_TRACER_SET_UINT32
 empty(::Type{JacobianTracer{Set{UInt64}}}) = EMPTY_JACOBIAN_TRACER_SET_UINT64
 
-JacobianTracer{S}(::Number) where {S<:AbstractIndexSet} = empty(JacobianTracer{S})
+JacobianTracer{S}(::Number) where {S} = empty(JacobianTracer{S})
 JacobianTracer(t::JacobianTracer) = t
 
 ## Unions of tracers
-function uniontracer(a::JacobianTracer{S}, b::JacobianTracer{S}) where {S<:AbstractIndexSet}
+function uniontracer(a::JacobianTracer{S}, b::JacobianTracer{S}) where {S}
     return JacobianTracer(union(a.inputs, b.inputs))
 end
 
@@ -108,10 +109,10 @@ The provided index set type `S` has to be an `AbstractSet{<:Integer}`, e.g. `Bit
 
 For a higher-level interface, refer to [`hessian_pattern`](@ref).
 """
-struct HessianTracer{S<:AbstractIndexSet} <: AbstractTracer
+struct HessianTracer{S} <: AbstractTracer
     inputs::Dict{UInt64,S}
 end
-function Base.show(io::IO, t::HessianTracer{S}) where {S<:AbstractIndexSet}
+function Base.show(io::IO, t::HessianTracer{S}) where {S}
     println(io, "HessianTracer{", S, "}(")
     for key in keys(t.inputs)
         print(io, "  ", key, " => ")
@@ -121,7 +122,7 @@ function Base.show(io::IO, t::HessianTracer{S}) where {S<:AbstractIndexSet}
     return print(io, ")")
 end
 
-function empty(::Type{HessianTracer{S}}) where {S<:AbstractIndexSet}
+function empty(::Type{HessianTracer{S}}) where {S}
     return HessianTracer(Dict{UInt64,S}())
 end
 
@@ -138,7 +139,7 @@ empty(::Type{HessianTracer{Set{UInt16}}}) = EMPTY_HESSIAN_TRACER_SET_UINT16
 empty(::Type{HessianTracer{Set{UInt32}}}) = EMPTY_HESSIAN_TRACER_SET_UINT32
 empty(::Type{HessianTracer{Set{UInt64}}}) = EMPTY_HESSIAN_TRACER_SET_UINT64
 
-HessianTracer{S}(::Number) where {S<:AbstractIndexSet} = empty(HessianTracer{S})
+HessianTracer{S}(::Number) where {S} = empty(HessianTracer{S})
 HessianTracer(t::HessianTracer) = t
 
 # Turn first-order interactions into second-order interactions
@@ -198,27 +199,20 @@ inputs(t::JacobianTracer) = collect(t.inputs)
 
 Convenience constructor for [`ConnectivityTracer`](@ref), [`JacobianTracer`](@ref) and [`HessianTracer`](@ref) from input indices.
 """
-tracer(::Type{JacobianTracer{S}}, index::Integer) where {S<:AbstractIndexSet} =
-    JacobianTracer(S(index))
-function tracer(::Type{ConnectivityTracer{S}}, index::Integer) where {S<:AbstractIndexSet}
+tracer(::Type{JacobianTracer{S}}, index::Integer) where {S} = JacobianTracer(S(index))
+function tracer(::Type{ConnectivityTracer{S}}, index::Integer) where {S}
     return ConnectivityTracer(S(index))
 end
-function tracer(::Type{HessianTracer{S}}, index::Integer) where {S<:AbstractIndexSet}
+function tracer(::Type{HessianTracer{S}}, index::Integer) where {S}
     return HessianTracer(Dict{UInt64,S}(index => S()))
 end
 
-function tracer(
-    ::Type{JacobianTracer{S}}, inds::NTuple{N,<:Integer}
-) where {N,S<:AbstractIndexSet}
+function tracer(::Type{JacobianTracer{S}}, inds::NTuple{N,<:Integer}) where {N,S}
     return JacobianTracer{S}(S(inds))
 end
-function tracer(
-    ::Type{ConnectivityTracer{S}}, inds::NTuple{N,<:Integer}
-) where {N,S<:AbstractIndexSet}
+function tracer(::Type{ConnectivityTracer{S}}, inds::NTuple{N,<:Integer}) where {N,S}
     return ConnectivityTracer{S}(S(inds))
 end
-function tracer(
-    ::Type{HessianTracer{S}}, inds::NTuple{N,<:Integer}
-) where {N,S<:AbstractIndexSet}
+function tracer(::Type{HessianTracer{S}}, inds::NTuple{N,<:Integer}) where {N,S}
     return HessianTracer{S}(Dict{UInt64,S}(i => S() for i in inds))
 end

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -7,16 +7,21 @@ empty(tracer::T) where {T<:AbstractTracer} = empty(T)
 # Connectivity #
 #==============#
 
+const SET_TYPE_MESSAGE = """
+The provided index set type `S` has to satisfy the following conditions:
+
+- it is an iterable with `<:Integer` element type
+- it implements methods `union`, `union!` and `push!`
+
+Subtypes of `AbstractSet{<:Integer}` are a natural choice, like `BitSet` or `Set{UInt64}`.
+"""
+
 """
     ConnectivityTracer{S}(indexset) <: Number
 
 Number type keeping track of input indices of previous computations.
-The provided index set type `S` has to satisfy the following conditions:
 
-- it is an iterable with `<:Integer` element type
-- it implements methods `union` and `push!`
-
-Subtypes of `AbstractSet{<:Integer}` are a natural choice, like `BitSet` or `Set{UInt64}`.
+$SET_TYPE_MESSAGE
 
 For a higher-level interface, refer to [`connectivity_pattern`](@ref).
 """
@@ -63,7 +68,8 @@ end
     JacobianTracer{S}(indexset) <: Number
 
 Number type keeping track of input indices of previous computations with non-zero derivatives.
-The provided index set type `S` has to be an `AbstractSet{<:Integer}`, e.g. `BitSet` or `Set{UInt64}`.
+
+$SET_TYPE_MESSAGE
 
 For a higher-level interface, refer to [`jacobian_pattern`](@ref).
 """
@@ -105,7 +111,8 @@ end
     HessianTracer{S}(indexset) <: Number
 
 Number type keeping track of input indices of previous computations with non-zero first and second derivatives.
-The provided index set type `S` has to be an `AbstractSet{<:Integer}`, e.g. `BitSet` or `Set{UInt64}`.
+
+$SET_TYPE_MESSAGE
 
 For a higher-level interface, refer to [`hessian_pattern`](@ref).
 """


### PR DESCRIPTION
Remove constraint `S <: AbstractSet{<:Integer}` in case we want to use vectors or other stuff.

Try to document the expectation of the tracer with respect to the "set" type.

See https://discourse.julialang.org/t/best-data-structure-for-fast-unions-of-large-sets-of-integers/113785/