### PR TITLE
Replace operator symbols with operator objects

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -23,63 +23,63 @@ is_seconder_zero_local(f::F, x) where {F} = is_seconder_zero_global(f)
 # ∂²f/∂x² != 0
 ops_1_to_1_s = (
     # trigonometric functions
-    :cos, :cosd, :cosh, :cospi, :cosc, 
-    :sin, :sind, :sinh, :sinpi, :sinc, 
-    :tan, :tand, :tanh,
+    cos, cosd, cosh, cospi, cosc, 
+    sin, sind, sinh, sinpi, sinc, 
+    tan, tand, tanh,
     # reciprocal trigonometric functions
-    :csc, :cscd, :csch, 
-    :sec, :secd, :sech, 
-    :cot, :cotd, :coth,
+    csc, cscd, csch, 
+    sec, secd, sech, 
+    cot, cotd, coth,
     # inverse trigonometric functions
-    :acos, :acosd, :acosh, 
-    :asin, :asind, :asinh, 
-    :atan, :atand, :atanh, 
-    :asec, :asech, 
-    :acsc, :acsch, 
-    :acot, :acoth,
+    acos, acosd, acosh, 
+    asin, asind, asinh, 
+    atan, atand, atanh, 
+    asec, asech, 
+    acsc, acsch, 
+    acot, acoth,
     # exponentials
-    :exp, :exp2, :exp10, :expm1, 
-    :log, :log2, :log10, :log1p, 
+    exp, exp2, exp10, expm1, 
+    log, log2, log10, log1p, 
     # roots
-    :sqrt, :cbrt,
+    sqrt, cbrt,
     # absolute values
-    :abs2,
+    abs2,
     # other
-    :inv,
+    inv,
 )
 for op in ops_1_to_1_s
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_zero_global(::T) = false
+    T = typeof(op)
+    @eval is_firstder_zero_global(::$T) = false
+    @eval is_seconder_zero_global(::$T) = false
 end
 
 # ops_1_to_1_f:
 # ∂f/∂x   != 0
 # ∂²f/∂x² == 0
 ops_1_to_1_f = (
-    :+, :-,
-    :identity,
-    :abs, :hypot,
-    :deg2rad, :rad2deg,
-    :mod2pi, :prevfloat, :nextfloat,
+    +, -,
+    identity,
+    abs, hypot,
+    deg2rad, rad2deg,
+    mod2pi, prevfloat, nextfloat,
 )
 for op in ops_1_to_1_f
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_zero_global(::T) = true
+    T = typeof(op)
+    @eval is_firstder_zero_global(::$T) = false
+    @eval is_seconder_zero_global(::$T) = true
 end
 
 # ops_1_to_1_z:
 # ∂f/∂x   == 0
 # ∂²f/∂x² == 0
 ops_1_to_1_z = (
-    :round, :floor, :ceil, :trunc,
-    :sign,
+    round, floor, ceil, trunc,
+    sign,
 )
 for op in ops_1_to_1_z
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_zero_global(::T) = true
-    SparseConnectivityTracer.is_seconder_zero_global(::T) = true
+    T = typeof(op)
+    @eval is_firstder_zero_global(::$T) = true
+    @eval is_seconder_zero_global(::$T) = true
 end
 
 ops_1_to_1 = union(
@@ -112,15 +112,15 @@ is_crossder_zero_local(f::F, x, y) where {F}      = is_crossder_zero_global(f)
 # ∂²f/∂y²  != 0
 # ∂²f/∂x∂y != 0
 ops_2_to_1_ssc = (
-    :^, :hypot
+    ^, hypot
 )
 for op in ops_2_to_1_ssc
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = false
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = false
+    @eval is_crossder_zero_global(::$T)      = false
 end
 
 # ops_2_to_1_ssz: 
@@ -130,14 +130,16 @@ end
 # ∂²f/∂y²  != 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_ssz = ()
-# for op in ops_2_to_1_ssz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_ssz
+    T = typeof(op)
+    @eval is_seconder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = false
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_sfc: 
 # ∂f/∂x    != 0
@@ -146,14 +148,16 @@ ops_2_to_1_ssz = ()
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y != 0
 ops_2_to_1_sfc = ()
-# for op in ops_2_to_1_sfc
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = false
-# end
+#=
+for op in ops_2_to_1_sfc
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = false
+end
+=#
 
 # ops_2_to_1_sfz: 
 # ∂f/∂x    != 0
@@ -162,14 +166,16 @@ ops_2_to_1_sfc = ()
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_sfz = ()
-# for op in ops_2_to_1_sfz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_sfz
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_fsc: 
 # ∂f/∂x    != 0
@@ -178,20 +184,20 @@ ops_2_to_1_sfz = ()
 # ∂²f/∂y²  != 0
 # ∂²f/∂x∂y != 0
 ops_2_to_1_fsc = (
-    :/, 
-    # :ldexp,  # TODO: removed for now
+    /, 
+    # ldexp,  # TODO: removed for now
 )
 for op in ops_2_to_1_fsc
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = false
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = false
+    @eval is_crossder_zero_global(::$T)      = false
 end
 
 # gradient of x/y: [1/y -x/y²]
-SparseConnectivityTracer.is_firstder_arg2_zero_local(::typeof(Base.:/), x, y) = iszero(x)
+SparseConnectivityTracer.is_firstder_arg2_zero_local(::typeof(/), x, y) = iszero(x)
 
 # ops_2_to_1_fsz: 
 # ∂f/∂x    != 0
@@ -200,14 +206,16 @@ SparseConnectivityTracer.is_firstder_arg2_zero_local(::typeof(Base.:/), x, y) = 
 # ∂²f/∂y²  != 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_fsz = ()
-# for op in ops_2_to_1_fsz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_fsz
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = false
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_ffc: 
 # ∂f/∂x    != 0
@@ -216,20 +224,20 @@ ops_2_to_1_fsz = ()
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y != 0
 ops_2_to_1_ffc = (
-    :*, 
+    *, 
 )
 for op in ops_2_to_1_ffc
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = false
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = false
 end
 
 # gradient of x*y: [y x]
-SparseConnectivityTracer.is_firstder_arg1_zero_local(::typeof(Base.:*), x, y) = iszero(y)
-SparseConnectivityTracer.is_firstder_arg2_zero_local(::typeof(Base.:*), x, y) = iszero(x)
+is_firstder_arg1_zero_local(::typeof(*), x, y) = iszero(y)
+is_firstder_arg2_zero_local(::typeof(*), x, y) = iszero(x)
 
 # ops_2_to_1_ffz: 
 # ∂f/∂x    != 0
@@ -238,20 +246,20 @@ SparseConnectivityTracer.is_firstder_arg2_zero_local(::typeof(Base.:*), x, y) = 
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_ffz = (
-    :+, :-,
-    :mod, :rem,
-    :min, :max,
+    +, -,
+    mod, rem,
+    min, max,
 )
 for op in ops_2_to_1_ffz
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
 end
 
-is_firstder_arg2_zero_local(::typeof(mod), x, y) = ifelse(y > 0, y > x, x > y)
+is_firstder_arg2_zero_local(::typeof(mod), x, y) = ifelse(y > zero(y), y > x, x > y)
 
 is_firstder_arg1_zero_local(::typeof(max), x, y) = x < y
 is_firstder_arg2_zero_local(::typeof(max), x, y) = y < x
@@ -266,14 +274,16 @@ is_firstder_arg2_zero_local(::typeof(min), x, y) = y > x
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_szz = ()
-# for op in ops_2_to_1_szz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_szz
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = false
+    @eval is_firstder_arg2_zero_global(::$T) = true
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_zsz: 
 # ∂f/∂x    == 0
@@ -282,14 +292,16 @@ ops_2_to_1_szz = ()
 # ∂²f/∂y²  != 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_zsz = ()
-# for op in ops_2_to_1_zsz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_zsz
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = true
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = false
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_fzz: 
 # ∂f/∂x    != 0
@@ -298,15 +310,15 @@ ops_2_to_1_zsz = ()
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_fzz = (
-    :copysign, :flipsign,
+    copysign, flipsign,
 )
 for op in ops_2_to_1_fzz
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = false
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = true
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
 end
 
 # ops_2_to_1_zfz: 
@@ -316,14 +328,16 @@ end
 # ∂²f/∂y²  == 0
 # ∂²f/∂x∂y == 0
 ops_2_to_1_zfz = ()
-# for op in ops_2_to_1_zfz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
-# end
+#=
+for op in ops_2_to_1_zfz
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = true
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = false
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
+end
+=#
 
 # ops_2_to_1_zfz: 
 # ∂f/∂x    == 0
@@ -333,15 +347,15 @@ ops_2_to_1_zfz = ()
 # ∂²f/∂x∂y == 0
 ops_2_to_1_zzz = (
     # division
-    :div, :fld, :fld1, :cld, 
+    div, fld, fld1, cld, 
 )
 for op in ops_2_to_1_zzz
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_seconder_arg1_zero_global(::T) = true
-    SparseConnectivityTracer.is_firstder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_seconder_arg2_zero_global(::T) = true
-    SparseConnectivityTracer.is_crossder_zero_global(::T)      = true
+    T = typeof(op)
+    @eval is_firstder_arg1_zero_global(::$T) = true
+    @eval is_seconder_arg1_zero_global(::$T) = true
+    @eval is_firstder_arg2_zero_global(::$T) = true
+    @eval is_seconder_arg2_zero_global(::$T) = true
+    @eval is_crossder_zero_global(::$T)      = true
 end
 
 ops_2_to_1 = union(
@@ -382,23 +396,22 @@ is_firstder_out1_zero_local(f::F, x) where {F} = is_firstder_out1_zero_global(f)
 is_firstder_out2_zero_local(f::F, x) where {F} = is_firstder_out2_zero_global(f)
 is_seconder_out2_zero_local(f::F, x) where {F} = is_seconder_out2_zero_global(f)
 
-
 # ops_1_to_2_ss: 
 # ∂f₁/∂x   != 0
 # ∂²f₁/∂x² != 0
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² != 0
 ops_1_to_2_ss = (
-    :sincos,
-    :sincosd,
-    :sincospi,
+    sincos,
+    sincosd,
+    sincospi,
 )
 for op in ops_1_to_2_ss
-    T = typeof(eval(op))
-    SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = false
-    SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-    SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = false
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = false
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = false
 end
 
 # ops_1_to_2_sf: 
@@ -407,13 +420,15 @@ end
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_sf = ()
-# for op in ops_1_to_2_sf
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_sf
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = false
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 # ops_1_to_2_sz: 
 # ∂f₁/∂x   != 0
@@ -421,13 +436,15 @@ ops_1_to_2_sf = ()
 # ∂f₂/∂x   == 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_sz = ()
-# for op in ops_1_to_2_sz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_sz
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = false
+    @eval is_firstder_out2_zero_global(::$T) = true
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 # ops_1_to_2_fs: 
 # ∂f₁/∂x   != 0
@@ -435,13 +452,15 @@ ops_1_to_2_sz = ()
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² != 0
 ops_1_to_2_fs = ()
-# for op in ops_1_to_2_fs
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = false
-# end
+#=
+for op in ops_1_to_2_fs
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = false
+end
+=#
 
 # ops_1_to_2_ff: 
 # ∂f₁/∂x   != 0
@@ -449,13 +468,15 @@ ops_1_to_2_fs = ()
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_ff = ()
-# for op in ops_1_to_2_ff
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_ff
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 # ops_1_to_2_fz: 
 # ∂f₁/∂x   != 0
@@ -463,15 +484,17 @@ ops_1_to_2_ff = ()
 # ∂f₂/∂x   == 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_fz = (
-    # :frexp,  # TODO: removed for now
+    # frexp,  # TODO: removed for now
 )
-# for op in ops_1_to_2_fz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_fz
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = false
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = true
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 # ops_1_to_2_zs: 
 # ∂f₁/∂x   == 0
@@ -479,13 +502,15 @@ ops_1_to_2_fz = (
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² != 0
 ops_1_to_2_zs = ()
-# for op in ops_1_to_2_zs
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = false
-# end
+#=
+for op in ops_1_to_2_zs
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = true
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = false
+end
+=#
 
 # ops_1_to_2_zf: 
 # ∂f₁/∂x   == 0
@@ -493,13 +518,15 @@ ops_1_to_2_zs = ()
 # ∂f₂/∂x   != 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_zf = ()
-# for op in ops_1_to_2_zf
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = false
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_zf
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = true
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = false
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 # ops_1_to_2_zz: 
 # ∂f₁/∂x   == 0
@@ -507,13 +534,15 @@ ops_1_to_2_zf = ()
 # ∂f₂/∂x   == 0
 # ∂²f₂/∂x² == 0
 ops_1_to_2_zz = ()
-# for op in ops_1_to_2_zz
-#     T = typeof(eval(op))
-#     SparseConnectivityTracer.is_firstder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out1_zero_global(::T) = true
-#     SparseConnectivityTracer.is_firstder_out2_zero_global(::T) = true
-#     SparseConnectivityTracer.is_seconder_out2_zero_global(::T) = true
-# end
+#=
+for op in ops_1_to_2_zz
+    T = typeof(op)
+    @eval is_firstder_out1_zero_global(::$T) = true
+    @eval is_seconder_out1_zero_global(::$T) = true
+    @eval is_firstder_out2_zero_global(::$T) = true
+    @eval is_seconder_out2_zero_global(::$T) = true
+end
+=#
 
 ops_1_to_2 = union(
     ops_1_to_2_ss,

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -1,5 +1,5 @@
 ## 1-to-1
-for fn in ops_1_to_1
+for fn in nameof.(ops_1_to_1)
     @eval Base.$fn(t::ConnectivityTracer) = t
     @eval function Base.$fn(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
         return Dual($fn(primal(d)), tracer(d))
@@ -7,7 +7,7 @@ for fn in ops_1_to_1
 end
 
 ## 2-to-1
-for fn in ops_2_to_1
+for fn in nameof.(ops_2_to_1)
     @eval Base.$fn(a::T, b::T) where {T<:ConnectivityTracer} = T(inputs(a) ∪ inputs(b))
     @eval function Base.$fn(da::D, db::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
         return Dual($fn(primal(da), primal(db)), $fn(tracer(da), tracer(db)))
@@ -23,7 +23,7 @@ for fn in ops_2_to_1
 end
 
 ## 1-to-2
-for fn in ops_1_to_2
+for fn in nameof.(ops_1_to_2)
     @eval Base.$fn(t::ConnectivityTracer) = (t, t)
     @eval function Base.$fn(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
         p1, p2 = $fn(primal(d))

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -7,7 +7,7 @@ function gradient_tracer_1_to_1(t::T, is_firstder_zero::Bool) where {T<:Gradient
     end
 end
 
-for fn in ops_1_to_1
+for fn in nameof.(ops_1_to_1)
     @eval function Base.$fn(t::GradientTracer)
         return gradient_tracer_1_to_1(t, is_firstder_zero_global($fn))
     end
@@ -38,7 +38,7 @@ function gradient_tracer_2_to_1(
     end
 end
 
-for fn in ops_2_to_1
+for fn in nameof.(ops_2_to_1)
     @eval function Base.$fn(tx::T, ty::T) where {T<:GradientTracer}
         return gradient_tracer_2_to_1(
             tx, ty, is_firstder_arg1_zero_global($fn), is_firstder_arg2_zero_global($fn)
@@ -87,7 +87,7 @@ function gradient_tracer_1_to_2(
     return (t1, t2)
 end
 
-for fn in ops_1_to_2
+for fn in nameof.(ops_1_to_2)
     @eval function Base.$fn(t::GradientTracer)
         return gradient_tracer_1_to_2(
             t, is_firstder_out1_zero_global($fn), is_firstder_out2_zero_global($fn)

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -17,7 +17,7 @@ function hessian_tracer_1_to_1(
     end
 end
 
-for fn in ops_1_to_1
+for fn in nameof.(ops_1_to_1)
     @eval function Base.$fn(t::HessianTracer)
         return hessian_tracer_1_to_1(
             t, is_firstder_zero_global($fn), is_seconder_zero_global($fn)
@@ -65,7 +65,7 @@ function hessian_tracer_2_to_1(
     return T(grad, hess)
 end
 
-for fn in ops_2_to_1
+for fn in nameof.(ops_2_to_1)
     @eval function Base.$fn(tx::T, ty::T) where {T<:HessianTracer}
         return hessian_tracer_2_to_1(
             tx,
@@ -138,7 +138,7 @@ function hessian_tracer_1_to_2(
     t2 = hessian_tracer_1_to_1(t, is_firstder_out2_zero, is_seconder_out2_zero)
     return (t1, t2)
 end
-for fn in ops_1_to_2
+for fn in nameof.(ops_1_to_2)
     @eval function Base.$fn(t::HessianTracer)
         return hessian_tracer_1_to_2(
             t,

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -42,8 +42,6 @@ random_input(::typeof(sincosd)) = 180 * rand()
 random_first_input(f) = random_input(f)
 random_second_input(f) = random_input(f)
 
-sym2fn(op::Symbol) = @eval Base.$op
-
 # Use enum as return type
 @enum Order begin
     zero_order   = 0
@@ -82,10 +80,9 @@ function classify_1_to_1(f, x; atol=DEFAULT_ATOL)
     return order
 end
 
-function classify_1_to_1(op::Symbol; atol=DEFAULT_ATOL, trials=100)
-    f = sym2fn(op)
+function classify_1_to_1(op; atol=DEFAULT_ATOL, trials=100)
     try
-        return maximum(classify_1_to_1(f, random_input(f); atol) for _ in 1:trials)
+        return maximum(classify_1_to_1(op, random_input(op); atol) for _ in 1:trials)
     catch e
         @warn "Classification of 1-to-1 operator $op failed" e
         return error_order
@@ -135,11 +132,10 @@ end
 classify_2_to_1(::typeof(max), x, y; atol) = (first_order, first_order, zero_order)
 classify_2_to_1(::typeof(min), x, y; atol) = (first_order, first_order, zero_order)
 
-function classify_2_to_1(op::Symbol; atol=1e-5, trials=100)
-    f = sym2fn(op)
+function classify_2_to_1(op; atol=1e-5, trials=100)
     try
         return maximum(
-            classify_2_to_1(f, random_first_input(f), random_second_input(f); atol) for
+            classify_2_to_1(op, random_first_input(op), random_second_input(op); atol) for
             _ in 1:trials
         )
     catch e
@@ -197,11 +193,10 @@ function classify_1_to_2(f, x; atol)
     return (first_out, second_out)
 end
 
-function classify_1_to_2(op::Symbol; atol=1e-5, trials=100)
-    f = sym2fn(op)
-    f_array(x) = [f(x)...]
+function classify_1_to_2(op; atol=1e-5, trials=100)
+    op_array(x) = [op(x)...]
     try
-        return maximum(classify_1_to_2(f_array, random_input(f); atol) for _ in 1:trials)
+        return maximum(classify_1_to_2(op_array, random_input(op); atol) for _ in 1:trials)
     catch e
         @warn "Classification of 1-to-2 operator `$op` failed" e
         return (error_order, error_order)

--- a/test/settypes/sortedvector.jl
+++ b/test/settypes/sortedvector.jl
@@ -9,20 +9,21 @@ using Test
         k1 in (0, 10, 100, 1000),
         k2 in (0, 10, 100, 1000)
 
-        for _ in 1:100
+        @test all(1:100) do _
             x = SortedVector{T}(rand(T(1):T(1000), k1); sorted=false)
             y = SortedVector{T}(sort(rand(T(1):T(1000), k2)); sorted=true)
             z = union(x, y)
-            @test eltype(z) == T
-            @test issorted(z.data)
-            @test Set(z.data) == union(Set(x.data), Set(y.data))
+            eltype(z) == T || return false
+            issorted(z.data) || return false
+            Set(z.data) == union(Set(x.data), Set(y.data)) || return false
             if k1 > 0 && k2 > 0
                 xc = collect(x)
                 yc = collect(y)
                 zc = collect(z)
-                @test zc[1] == min(xc[1], yc[1])
-                @test zc[end] == max(xc[end], yc[end])
+                zc[1] == min(xc[1], yc[1]) || return false
+                zc[end] == max(xc[end], yc[end]) || return false
             end
+            return true
         end
     end
 end;


### PR DESCRIPTION
Changes:

- Replace the lists of symbols with lists of actual objects
- (Not important) Group tests for `SortedVector` so that they don't skew the total number of tests

Benefits:

- No need to extend `SparseConnectivityTracer.iszero_...`, just `iszero_...`
- Hovering on the symbols gives you the docstring, which is very helpful in this file for classification

I suspect this change could also allow us to avoid metaprogramming altogether in the `overloads...` files, but I haven't yet figured out how