### PR TITLE
Revamp classification tests

### DIFF
--- a/test/classification.jl
+++ b/test/classification.jl
@@ -1,116 +1,76 @@
 using SparseConnectivityTracer:
     ops_1_to_1,
-    ops_1_to_1_s,
-    ops_1_to_1_f,
-    ops_1_to_1_z,
+    is_firstder_zero_global,
+    is_seconder_zero_global,
+    is_firstder_zero_local,
+    is_seconder_zero_local,
     ops_2_to_1,
-    ops_2_to_1_ssc,
-    ops_2_to_1_ssz,
-    ops_2_to_1_sfc,
-    ops_2_to_1_sfz,
-    ops_2_to_1_fsc,
-    ops_2_to_1_fsz,
-    ops_2_to_1_ffc,
-    ops_2_to_1_ffz,
-    ops_2_to_1_szz,
-    ops_2_to_1_zsz,
-    ops_2_to_1_fzz,
-    ops_2_to_1_zfz,
-    ops_2_to_1_zzz,
+    is_firstder_arg1_zero_global,
+    is_seconder_arg1_zero_global,
+    is_firstder_arg2_zero_global,
+    is_seconder_arg2_zero_global,
+    is_crossder_zero_global,
+    is_firstder_arg1_zero_local,
+    is_seconder_arg1_zero_local,
+    is_firstder_arg2_zero_local,
+    is_seconder_arg2_zero_local,
+    is_crossder_zero_local,
     ops_1_to_2,
-    ops_1_to_2_ss,
-    ops_1_to_2_sf,
-    ops_1_to_2_fs,
-    ops_1_to_2_ff,
-    ops_1_to_2_sz,
-    ops_1_to_2_zs,
-    ops_1_to_2_fz,
-    ops_1_to_2_zf,
-    ops_1_to_2_zz
+    is_firstder_out1_zero_global,
+    is_seconder_out1_zero_global,
+    is_firstder_out2_zero_global,
+    is_seconder_out2_zero_global,
+    is_seconder_out1_zero_local,
+    is_firstder_out1_zero_local,
+    is_firstder_out2_zero_local,
+    is_seconder_out2_zero_local
 using Test
 using ForwardDiff: derivative, gradient, hessian
 
 second_derivative(f, x) = derivative(_x -> derivative(f, _x), x)
 
 DEFAULT_ATOL = 1e-8
-isapproxzero(x; atol=DEFAULT_ATOL) = abs(x) <= atol
+DEFAULT_TRIALS = 20
 
-random_input(f) = rand()
+## Random inputs
+
+random_input(op) = rand()
 random_input(::Union{typeof(acosh),typeof(acoth),typeof(acsc),typeof(asec)}) = 1 + rand()
 random_input(::typeof(sincosd)) = 180 * rand()
 
-random_first_input(f) = random_input(f)
-random_second_input(f) = random_input(f)
-
-# Use enum as return type
-@enum Order begin
-    zero_order   = 0
-    first_order  = 1
-    second_order = 2
-    error_order  = -1
-end
-
-function differentiability(∂f∂x, ∂²f∂x²; atol=DEFAULT_ATOL)
-    is_∂f∂x_zero   = isapproxzero(∂f∂x; atol)
-    is_∂²f∂x²_zero = isapproxzero(∂²f∂x²; atol)
-
-    if !is_∂f∂x_zero
-        if !is_∂²f∂x²_zero
-            return second_order
-        else
-            return first_order
-        end
-    else # is_∂f∂x_zero
-        if is_∂²f∂x²_zero
-            return zero_order
-        else
-            return error_order
-        end
-    end
-end
+random_first_input(op) = random_input(op)
+random_second_input(op) = random_input(op)
 
 ## 1-to-1
 
-function classify_1_to_1(f, x; atol=DEFAULT_ATOL)
-    ∂f∂x = derivative(f, x)
-    ∂²f∂x² = second_derivative(f, x)
-
-    order = differentiability(∂f∂x, ∂²f∂x²; atol)
-    order == error_order && @warn "Weird behavior" f x ∂f∂x ∂²f∂x²
-    return order
-end
-
-function classify_1_to_1(op; atol=DEFAULT_ATOL, trials=100)
-    try
-        return maximum(classify_1_to_1(op, random_input(op); atol) for _ in 1:trials)
-    catch e
-        @warn "Classification of 1-to-1 operator $op failed" e
-        return error_order
+function correct_classification_1_to_1(op, x; atol)
+    dfdx = derivative(op, x)
+    d²fdx² = second_derivative(op, x)
+    if (is_firstder_zero_global(op) | is_firstder_zero_local(op, x)) &&
+        !isapprox(dfdx, 0; atol)
+        return false
+    elseif (is_seconder_zero_global(op) | is_seconder_zero_local(op, x)) &&
+        !isapprox(d²fdx², 0; atol)
+        return false
+    else
+        return true
     end
 end
 
-const TEST_1_TO_1 = (
-    ("Second order", ops_1_to_1_s, second_order),
-    ("First order", ops_1_to_1_f, first_order),
-    ("Zero order", ops_1_to_1_z, zero_order),
-)
 @testset verbose = true "1-to-1" begin
-    for (name, ops, ref_order) in TEST_1_TO_1
-        @testset "$name" begin
-            for op in ops
-                @testset "$op" begin
-                    @test classify_1_to_1(op) == ref_order
-                end
-            end
-        end
+    @testset "$op" for op in ops_1_to_1
+        @test all(
+            correct_classification_1_to_1(op, random_input(op); atol=DEFAULT_ATOL) for
+            _ in 1:DEFAULT_TRIALS
+        )
     end
 end;
 
 ## 2-to-1
 
-function classify_2_to_1(f, x, y; atol)
-    g = gradient(Base.splat(f), [x, y])
-    H = hessian(Base.splat(f), [x, y])
+function correct_classification_2_to_1(op, x, y; atol)
+    g = gradient(Base.splat(op), [x, y])
+    H = hessian(Base.splat(op), [x, y])
 
     ∂f∂x    = g[1]
     ∂f∂y    = g[2]
@@ -118,114 +78,73 @@ function classify_2_to_1(f, x, y; atol)
     ∂²f∂y²  = H[2, 2]
     ∂²f∂x∂y = H[1, 2]
 
-    first_arg = differentiability(∂f∂x, ∂²f∂x²; atol)
-    first_arg == error_order && @warn "Weird behavior on argument x" f x y ∂f∂x ∂²f∂x²
-
-    second_arg = differentiability(∂f∂y, ∂²f∂y²; atol)
-    second_arg == error_order && @warn "Weird behavior on argument y" f x y ∂f∂y ∂²f∂y²
-
-    cross = isapproxzero(∂²f∂x∂y; atol) ? zero_order : second_order
-    return (first_arg, second_arg, cross)
-end
-
-# Some exceptions have to be manually specified
-classify_2_to_1(::typeof(max), x, y; atol) = (first_order, first_order, zero_order)
-classify_2_to_1(::typeof(min), x, y; atol) = (first_order, first_order, zero_order)
-
-function classify_2_to_1(op; atol=1e-5, trials=100)
-    try
-        return maximum(
-            classify_2_to_1(op, random_first_input(op), random_second_input(op); atol) for
-            _ in 1:trials
-        )
-    catch e
-        @warn "Classification of 2-to-1 operator `$op` failed" e
-        return (error_order, error_order, error_order)
+    if (is_firstder_arg1_zero_global(op) | is_firstder_arg1_zero_local(op, x, y)) &&
+        !isapprox(∂f∂x, 0; atol)
+        return false
+    elseif (is_seconder_arg1_zero_global(op) | is_seconder_arg1_zero_local(op, x, y)) &&
+        !isapprox(∂²f∂x², 0; atol)
+        return false
+    elseif (is_firstder_arg2_zero_global(op) | is_firstder_arg2_zero_local(op, x, y)) &&
+        !isapprox(∂f∂y, 0; atol)
+        return false
+    elseif (is_seconder_arg2_zero_global(op) | is_seconder_arg2_zero_local(op, x, y)) &&
+        !isapprox(∂²f∂y², 0; atol)
+        return false
+    elseif (is_crossder_zero_global(op) | is_crossder_zero_local(op, x, y)) &&
+        !isapprox(∂²f∂x∂y, 0; atol)
+        return false
+    else
+        return true
     end
 end
 
-const TEST_2_TO_1 = (
-    ("ssc", ops_2_to_1_ssc, (second_order, second_order, second_order)),
-    ("ssz", ops_2_to_1_ssz, (second_order, second_order, zero_order)),
-    ("sfc", ops_2_to_1_sfc, (second_order, first_order, second_order)),
-    ("sfz", ops_2_to_1_sfz, (second_order, first_order, zero_order)),
-    ("fsc", ops_2_to_1_fsc, (first_order, second_order, second_order)),
-    ("fsz", ops_2_to_1_fsz, (first_order, second_order, zero_order)),
-    ("ffc", ops_2_to_1_ffc, (first_order, first_order, second_order)),
-    ("ffz", ops_2_to_1_ffz, (first_order, first_order, zero_order)),
-    ("szz", ops_2_to_1_szz, (second_order, zero_order, zero_order)),
-    ("zsz", ops_2_to_1_zsz, (zero_order, second_order, zero_order)),
-    ("fzz", ops_2_to_1_fzz, (first_order, zero_order, zero_order)),
-    ("zfz", ops_2_to_1_zfz, (zero_order, second_order, zero_order)),
-    ("zzz", ops_2_to_1_zzz, (zero_order, zero_order, zero_order)),
-)
 @testset verbose = true "2-to-1" begin
-    @testset "All operators covered" begin
-        all_ops = union([ops for (name, ops, ref_order) in TEST_2_TO_1]...)
-        @test Set(all_ops) == Set(ops_2_to_1)
-    end
-    for (name, ops, ref_order) in TEST_2_TO_1
-        @testset "$name" begin
-            for op in ops
-                @testset "$op" begin
-                    @test classify_2_to_1(op) == ref_order
-                end
-            end
-        end
+    @testset "$op" for op in ops_2_to_1
+        @test all(
+            correct_classification_2_to_1(
+                op, random_first_input(op), random_second_input(op); atol=DEFAULT_ATOL
+            ) for _ in 1:DEFAULT_TRIALS
+        )
     end
 end;
 
 ## 1-to-2
 
-function classify_1_to_2(f, x; atol)
-    d1 = derivative(f, x)
-    d2 = second_derivative(f, x)
+function correct_classification_1_to_2(op, x; atol)
+    function op_vec(x)
+        y = op(x)
+        return [y[1], y[2]]
+    end
+    d1 = derivative(op_vec, x)
+    d2 = second_derivative(op_vec, x)
 
     ∂f₁∂x = d1[1]
     ∂f₂∂x = d1[2]
     ∂²f₁∂x² = d2[1]
     ∂²f₂∂x² = d2[2]
 
-    first_out = differentiability(∂f₁∂x, ∂²f₁∂x²; atol)
-    first_out == error_order && @warn "Weird behavior w.r.t. 1st output" f x ∂f₁∂x ∂²f₁∂x²
-    second_out = differentiability(∂f₂∂x, ∂²f₂∂x²; atol)
-    first_out == error_order && @warn "Weird behavior w.r.t. 2nd output" f x ∂f₂∂x ∂²f₂∂x²
-    return (first_out, second_out)
-end
-
-function classify_1_to_2(op; atol=1e-5, trials=100)
-    op_array(x) = [op(x)...]
-    try
-        return maximum(classify_1_to_2(op_array, random_input(op); atol) for _ in 1:trials)
-    catch e
-        @warn "Classification of 1-to-2 operator `$op` failed" e
-        return (error_order, error_order)
+    if (is_firstder_out1_zero_global(op) | is_firstder_out1_zero_local(op, x)) &&
+        !isapprox(∂f₁∂x, 0; atol)
+        return false
+    elseif (is_seconder_out1_zero_global(op) | is_seconder_out1_zero_local(op, x)) &&
+        !isapprox(∂²f₁∂x², 0; atol)
+        return false
+    elseif (is_firstder_out2_zero_global(op) | is_firstder_out2_zero_local(op, x)) &&
+        !isapprox(∂f₂∂x, 0; atol)
+        return false
+    elseif (is_seconder_out2_zero_global(op) | is_seconder_out2_zero_local(op, x)) &&
+        !isapprox(∂²f₂∂x², 0; atol)
+        return false
+    else
+        return true
     end
 end
 
-const TEST_1_TO_2 = (
-    ("ss", ops_1_to_2_ss, (second_order, second_order)),
-    ("sf", ops_1_to_2_sf, (second_order, first_order)),
-    ("fs", ops_1_to_2_fs, (first_order, second_order)),
-    ("ff", ops_1_to_2_ff, (first_order, first_order)),
-    ("sz", ops_1_to_2_sz, (second_order, zero_order)),
-    ("zs", ops_1_to_2_zs, (zero_order, second_order)),
-    ("fz", ops_1_to_2_fz, (first_order, zero_order)),
-    ("zf", ops_1_to_2_zf, (zero_order, second_order)),
-    ("zz", ops_1_to_2_zz, (zero_order, zero_order)),
-)
 @testset verbose = true "1-to-2" begin
-    @testset "All operators covered" begin
-        all_ops = union([ops for (name, ops, ref_order) in TEST_1_TO_2]...)
-        @test Set(all_ops) == Set(ops_1_to_2)
-    end
-    for (name, ops, ref_order) in TEST_1_TO_2
-        @testset "$name" begin
-            for op in ops
-                @testset "$op" begin
-                    @test classify_1_to_2(op) == ref_order
-                end
-            end
-        end
+    @testset "$op" for op in ops_1_to_2
+        @test all(
+            correct_classification_1_to_2(op, random_input(op); atol=DEFAULT_ATOL) for
+            _ in 1:DEFAULT_TRIALS
+        )
     end
 end;


### PR DESCRIPTION
This PR replaces the hacky classification tests based on symbols with tests that use the traits defined internally. Essentially, if we declare that a derivative is zero (locally or globally), we check that ForwardDiff agrees. Note that we don't check the other way around, which means we are free to underspecify zeros