### PR TITLE
Put overloading mechanism into functions

### DIFF
--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -2,42 +2,36 @@
 
 function overload_connectivity_1_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        $ms.$fns(t::ConnectivityTracer) = t
-        $ms.$fns(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-            Dual($ms.$fns(primal(d)), tracer(d))
-    end
+    @eval $ms.$fns(t::ConnectivityTracer) = t
+    @eval $ms.$fns(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
+        Dual($ms.$fns(primal(d)), tracer(d))
 end
 
 ## 2-to-1
 
 function overload_connectivity_2_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        $ms.$fns(a::T, b::T) where {T<:ConnectivityTracer} = T(inputs(a) ∪ inputs(b))
-        $ms.$fns(da::D, db::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-            Dual($ms.$fns(primal(da), primal(db)), $ms.$fns(tracer(da), tracer(db)))
+    @eval $ms.$fns(a::T, b::T) where {T<:ConnectivityTracer} = T(inputs(a) ∪ inputs(b))
+    @eval $ms.$fns(da::D, db::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
+        Dual($ms.$fns(primal(da), primal(db)), $ms.$fns(tracer(da), tracer(db)))
 
-        $ms.$fns(t::ConnectivityTracer, ::Number) = t
-        $ms.$fns(dx::D, y::Number) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-            Dual($ms.$fns(primal(dx), y), tracer(dx))
+    @eval $ms.$fns(t::ConnectivityTracer, ::Number) = t
+    @eval $ms.$fns(dx::D, y::Number) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
+        Dual($ms.$fns(primal(dx), y), tracer(dx))
 
-        $ms.$fns(::Number, t::ConnectivityTracer) = t
-        $ms.$fns(x::Number, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-            Dual($ms.$fns(x, primal(dy)), tracer(dy))
-    end
+    @eval $ms.$fns(::Number, t::ConnectivityTracer) = t
+    @eval $ms.$fns(x::Number, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
+        Dual($ms.$fns(x, primal(dy)), tracer(dy))
 end
 
 ## 1-to-2
 
 function overload_connectivity_1_to_2(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        $ms.$fns(t::ConnectivityTracer) = (t, t)
-        function $ms.$fns(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
-            p1, p2 = $ms.$fns(primal(d))
-            return (Dual(p1, tracer(d)), Dual(p2, tracer(d)))
-        end
+    @eval $ms.$fns(t::ConnectivityTracer) = (t, t)
+    @eval function $ms.$fns(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
+        p1, p2 = $ms.$fns(primal(d))
+        return (Dual(p1, tracer(d)), Dual(p2, tracer(d)))
     end
 end
 

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -10,16 +10,14 @@ end
 
 function overload_gradient_1_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(t::GradientTracer)
-            return gradient_tracer_1_to_1(t, is_firstder_zero_global($ms.$fns))
-        end
-        function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-            x = primal(d)
-            p_out = $ms.$fns(x)
-            t_out = gradient_tracer_1_to_1(tracer(d), is_firstder_zero_local($fns, x))
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(t::GradientTracer)
+        return gradient_tracer_1_to_1(t, is_firstder_zero_global($ms.$fns))
+    end
+    @eval function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+        x = primal(d)
+        p_out = $ms.$fns(x)
+        t_out = gradient_tracer_1_to_1(tracer(d), is_firstder_zero_local($fns, x))
+        return Dual(p_out, t_out)
     end
 end
 
@@ -45,51 +43,49 @@ end
 
 function overload_gradient_2_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(tx::T, ty::T) where {T<:GradientTracer}
-            return gradient_tracer_2_to_1(
-                tx,
-                ty,
-                is_firstder_arg1_zero_global($ms.$fns),
-                is_firstder_arg2_zero_global($ms.$fns),
-            )
-        end
-        function $ms.$fns(dx::D, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-            x = primal(dx)
-            y = primal(dy)
-            p_out = $ms.$fns(x, y)
-            t_out = gradient_tracer_2_to_1(
-                tracer(dx),
-                tracer(dy),
-                is_firstder_arg1_zero_local($ms.$fns, x, y),
-                is_firstder_arg2_zero_local($ms.$fns, x, y),
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(tx::T, ty::T) where {T<:GradientTracer}
+        return gradient_tracer_2_to_1(
+            tx,
+            ty,
+            is_firstder_arg1_zero_global($ms.$fns),
+            is_firstder_arg2_zero_global($ms.$fns),
+        )
+    end
+    @eval function $ms.$fns(dx::D, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        y = primal(dy)
+        p_out = $ms.$fns(x, y)
+        t_out = gradient_tracer_2_to_1(
+            tracer(dx),
+            tracer(dy),
+            is_firstder_arg1_zero_local($ms.$fns, x, y),
+            is_firstder_arg2_zero_local($ms.$fns, x, y),
+        )
+        return Dual(p_out, t_out)
+    end
 
-        function $ms.$fns(tx::GradientTracer, ::Number)
-            return gradient_tracer_1_to_1(tx, is_firstder_arg1_zero_global($ms.$fns))
-        end
-        function $ms.$fns(dx::D, y::Number) where {P,T<:GradientTracer,D<:Dual{P,T}}
-            x = primal(dx)
-            p_out = $ms.$fns(x, y)
-            t_out = gradient_tracer_1_to_1(
-                tracer(dx), is_firstder_arg1_zero_local($ms.$fns, x, y)
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(tx::GradientTracer, ::Number)
+        return gradient_tracer_1_to_1(tx, is_firstder_arg1_zero_global($ms.$fns))
+    end
+    @eval function $ms.$fns(dx::D, y::Number) where {P,T<:GradientTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        p_out = $ms.$fns(x, y)
+        t_out = gradient_tracer_1_to_1(
+            tracer(dx), is_firstder_arg1_zero_local($ms.$fns, x, y)
+        )
+        return Dual(p_out, t_out)
+    end
 
-        function $ms.$fns(::Number, ty::GradientTracer)
-            return gradient_tracer_1_to_1(ty, is_firstder_arg2_zero_global($ms.$fns))
-        end
-        function $ms.$fns(x::Number, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-            y = primal(dy)
-            p_out = $ms.$fns(x, y)
-            t_out = gradient_tracer_1_to_1(
-                tracer(dy), is_firstder_arg2_zero_local($ms.$fns, x, y)
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(::Number, ty::GradientTracer)
+        return gradient_tracer_1_to_1(ty, is_firstder_arg2_zero_global($ms.$fns))
+    end
+    @eval function $ms.$fns(x::Number, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+        y = primal(dy)
+        p_out = $ms.$fns(x, y)
+        t_out = gradient_tracer_1_to_1(
+            tracer(dy), is_firstder_arg2_zero_local($ms.$fns, x, y)
+        )
+        return Dual(p_out, t_out)
     end
 end
 
@@ -105,25 +101,23 @@ end
 
 function overload_gradient_1_to_2(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(t::GradientTracer)
-            return gradient_tracer_1_to_2(
-                t,
-                is_firstder_out1_zero_global($ms.$fns),
-                is_firstder_out2_zero_global($ms.$fns),
-            )
-        end
+    @eval function $ms.$fns(t::GradientTracer)
+        return gradient_tracer_1_to_2(
+            t,
+            is_firstder_out1_zero_global($ms.$fns),
+            is_firstder_out2_zero_global($ms.$fns),
+        )
+    end
 
-        function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-            x = primal(d)
-            p1_out, p2_out = $ms.$fns(x)
-            t1_out, t2_out = gradient_tracer_1_to_2(
-                t,
-                is_firstder_out1_zero_local($ms.$fns, x),
-                is_firstder_out2_zero_local($ms.$fns, x),
-            )
-            return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))  # TODO: this was wrong, add test
-        end
+    @eval function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+        x = primal(d)
+        p1_out, p2_out = $ms.$fns(x)
+        t1_out, t2_out = gradient_tracer_1_to_2(
+            t,
+            is_firstder_out1_zero_local($ms.$fns, x),
+            is_firstder_out2_zero_local($ms.$fns, x),
+        )
+        return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))  # TODO: this was wrong, add test
     end
 end
 

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -1,4 +1,5 @@
 ## 1-to-1
+
 function gradient_tracer_1_to_1(t::T, is_firstder_zero::Bool) where {T<:GradientTracer}
     if is_firstder_zero
         return empty(T)
@@ -7,19 +8,23 @@ function gradient_tracer_1_to_1(t::T, is_firstder_zero::Bool) where {T<:Gradient
     end
 end
 
-for fn in nameof.(ops_1_to_1)
-    @eval function Base.$fn(t::GradientTracer)
-        return gradient_tracer_1_to_1(t, is_firstder_zero_global($fn))
-    end
-    @eval function Base.$fn(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-        x = primal(d)
-        p_out = Base.$fn(x)
-        t_out = gradient_tracer_1_to_1(tracer(d), is_firstder_zero_local($fn, x))
-        return Dual(p_out, t_out)
+function overload_gradient_1_to_1(m::Module, fn::Function)
+    ms, fns = nameof(m), nameof(fn)
+    @eval begin
+        function $ms.$fns(t::GradientTracer)
+            return gradient_tracer_1_to_1(t, is_firstder_zero_global($ms.$fns))
+        end
+        function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+            x = primal(d)
+            p_out = $ms.$fns(x)
+            t_out = gradient_tracer_1_to_1(tracer(d), is_firstder_zero_local($fns, x))
+            return Dual(p_out, t_out)
+        end
     end
 end
 
 ## 2-to-1
+
 function gradient_tracer_2_to_1(
     tx::T, ty::T, is_firstder_arg1_zero::Bool, is_firstder_arg2_zero::Bool
 ) where {T<:GradientTracer}
@@ -38,47 +43,58 @@ function gradient_tracer_2_to_1(
     end
 end
 
-for fn in nameof.(ops_2_to_1)
-    @eval function Base.$fn(tx::T, ty::T) where {T<:GradientTracer}
-        return gradient_tracer_2_to_1(
-            tx, ty, is_firstder_arg1_zero_global($fn), is_firstder_arg2_zero_global($fn)
-        )
-    end
-    @eval function Base.$fn(dx::D, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-        x = primal(dx)
-        y = primal(dy)
-        p_out = Base.$fn(x, y)
-        t_out = gradient_tracer_2_to_1(
-            tracer(dx),
-            tracer(dy),
-            is_firstder_arg1_zero_local($fn, x, y),
-            is_firstder_arg2_zero_local($fn, x, y),
-        )
-        return Dual(p_out, t_out)
-    end
+function overload_gradient_2_to_1(m::Module, fn::Function)
+    ms, fns = nameof(m), nameof(fn)
+    @eval begin
+        function $ms.$fns(tx::T, ty::T) where {T<:GradientTracer}
+            return gradient_tracer_2_to_1(
+                tx,
+                ty,
+                is_firstder_arg1_zero_global($ms.$fns),
+                is_firstder_arg2_zero_global($ms.$fns),
+            )
+        end
+        function $ms.$fns(dx::D, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+            x = primal(dx)
+            y = primal(dy)
+            p_out = $ms.$fns(x, y)
+            t_out = gradient_tracer_2_to_1(
+                tracer(dx),
+                tracer(dy),
+                is_firstder_arg1_zero_local($ms.$fns, x, y),
+                is_firstder_arg2_zero_local($ms.$fns, x, y),
+            )
+            return Dual(p_out, t_out)
+        end
 
-    @eval function Base.$fn(tx::GradientTracer, ::Number)
-        return gradient_tracer_1_to_1(tx, is_firstder_arg1_zero_global($fn))
-    end
-    @eval function Base.$fn(dx::D, y::Number) where {P,T<:GradientTracer,D<:Dual{P,T}}
-        x = primal(dx)
-        p_out = Base.$fn(x, y)
-        t_out = gradient_tracer_1_to_1(tracer(dx), is_firstder_arg1_zero_local($fn, x, y))
-        return Dual(p_out, t_out)
-    end
+        function $ms.$fns(tx::GradientTracer, ::Number)
+            return gradient_tracer_1_to_1(tx, is_firstder_arg1_zero_global($ms.$fns))
+        end
+        function $ms.$fns(dx::D, y::Number) where {P,T<:GradientTracer,D<:Dual{P,T}}
+            x = primal(dx)
+            p_out = $ms.$fns(x, y)
+            t_out = gradient_tracer_1_to_1(
+                tracer(dx), is_firstder_arg1_zero_local($ms.$fns, x, y)
+            )
+            return Dual(p_out, t_out)
+        end
 
-    @eval function Base.$fn(::Number, ty::GradientTracer)
-        return gradient_tracer_1_to_1(ty, is_firstder_arg2_zero_global($fn))
-    end
-    @eval function Base.$fn(x::Number, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-        y = primal(dy)
-        p_out = Base.$fn(x, y)
-        t_out = gradient_tracer_1_to_1(tracer(dy), is_firstder_arg2_zero_local($fn, x, y))
-        return Dual(p_out, t_out)
+        function $ms.$fns(::Number, ty::GradientTracer)
+            return gradient_tracer_1_to_1(ty, is_firstder_arg2_zero_global($ms.$fns))
+        end
+        function $ms.$fns(x::Number, dy::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+            y = primal(dy)
+            p_out = $ms.$fns(x, y)
+            t_out = gradient_tracer_1_to_1(
+                tracer(dy), is_firstder_arg2_zero_local($ms.$fns, x, y)
+            )
+            return Dual(p_out, t_out)
+        end
     end
 end
 
 ## 1-to-2
+
 function gradient_tracer_1_to_2(
     t::T, is_firstder_out1_zero::Bool, is_firstder_out2_zero::Bool
 ) where {T<:GradientTracer}
@@ -87,24 +103,48 @@ function gradient_tracer_1_to_2(
     return (t1, t2)
 end
 
-for fn in nameof.(ops_1_to_2)
-    @eval function Base.$fn(t::GradientTracer)
-        return gradient_tracer_1_to_2(
-            t, is_firstder_out1_zero_global($fn), is_firstder_out2_zero_global($fn)
-        )
-    end
+function overload_gradient_1_to_2(m::Module, fn::Function)
+    ms, fns = nameof(m), nameof(fn)
+    @eval begin
+        function $ms.$fns(t::GradientTracer)
+            return gradient_tracer_1_to_2(
+                t,
+                is_firstder_out1_zero_global($ms.$fns),
+                is_firstder_out2_zero_global($ms.$fns),
+            )
+        end
 
-    @eval function Base.$fn(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
-        x = primal(d)
-        p1_out, p2_out = Base.$fn(x)
-        t1_out, t2_out = gradient_tracer_1_to_2(
-            t, is_firstder_out1_zero_local($fn, x), is_firstder_out2_zero_local($fn, x)
-        )
-        return (Dual(p1_out, t1_out), Dual(p1_out, t1_out))
+        function $ms.$fns(d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
+            x = primal(d)
+            p1_out, p2_out = $ms.$fns(x)
+            t1_out, t2_out = gradient_tracer_1_to_2(
+                t,
+                is_firstder_out1_zero_local($ms.$fns, x),
+                is_firstder_out2_zero_local($ms.$fns, x),
+            )
+            return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))  # TODO: this was wrong, add test
+        end
     end
 end
 
-# Extra types required for exponent 
+## Actual overloads
+
+for op in ops_1_to_1
+    overload_gradient_1_to_1(Base, op)
+end
+
+for op in ops_2_to_1
+    overload_gradient_2_to_1(Base, op)
+end
+
+for op in ops_1_to_2
+    overload_gradient_1_to_2(Base, op)
+end
+
+## Special cases
+
+## Exponent (requires extra types)
+
 for S in (Real, Integer, Rational, Irrational{:ℯ})
     Base.:^(t::GradientTracer, ::S) = t
     Base.:^(::S, t::GradientTracer) = t
@@ -126,4 +166,4 @@ function Base.round(
 end
 
 ## Random numbers 
-rand(::AbstractRNG, ::SamplerType{T}) where {T<:GradientTracer} = empty(T)
+Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:GradientTracer} = empty(T)  # TODO: was missing Base, add tests

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -20,22 +20,20 @@ end
 
 function overload_hessian_1_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(t::HessianTracer)
-            return hessian_tracer_1_to_1(
-                t, is_firstder_zero_global($ms.$fns), is_seconder_zero_global($ms.$fns)
-            )
-        end
-        function $ms.$fns(d::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
-            x = primal(d)
-            p_out = $ms.$fns(x)
-            t_out = hessian_tracer_1_to_1(
-                tracer(d),
-                is_firstder_zero_local($ms.$fns, x),
-                is_seconder_zero_local($ms.$fns, x),
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(t::HessianTracer)
+        return hessian_tracer_1_to_1(
+            t, is_firstder_zero_global($ms.$fns), is_seconder_zero_global($ms.$fns)
+        )
+    end
+    @eval function $ms.$fns(d::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
+        x = primal(d)
+        p_out = $ms.$fns(x)
+        t_out = hessian_tracer_1_to_1(
+            tracer(d),
+            is_firstder_zero_local($ms.$fns, x),
+            is_seconder_zero_local($ms.$fns, x),
+        )
+        return Dual(p_out, t_out)
     end
 end
 
@@ -74,69 +72,67 @@ end
 
 function overload_hessian_2_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(tx::T, ty::T) where {T<:HessianTracer}
-            return hessian_tracer_2_to_1(
-                tx,
-                ty,
-                is_firstder_arg1_zero_global($ms.$fns),
-                is_seconder_arg1_zero_global($ms.$fns),
-                is_firstder_arg2_zero_global($ms.$fns),
-                is_seconder_arg2_zero_global($ms.$fns),
-                is_crossder_zero_global($ms.$fns),
-            )
-        end
-        function $ms.$fns(dx::D, dy::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
-            x = primal(dx)
-            y = primal(dy)
-            p_out = $ms.$fns(x, y)
-            t_out = hessian_tracer_2_to_1(
-                tracer(dx),
-                tracer(dy),
-                is_firstder_arg1_zero_local($ms.$fns, x, y),
-                is_seconder_arg1_zero_local($ms.$fns, x, y),
-                is_firstder_arg2_zero_local($ms.$fns, x, y),
-                is_seconder_arg2_zero_local($ms.$fns, x, y),
-                is_crossder_zero_local($ms.$fns, x, y),
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(tx::T, ty::T) where {T<:HessianTracer}
+        return hessian_tracer_2_to_1(
+            tx,
+            ty,
+            is_firstder_arg1_zero_global($ms.$fns),
+            is_seconder_arg1_zero_global($ms.$fns),
+            is_firstder_arg2_zero_global($ms.$fns),
+            is_seconder_arg2_zero_global($ms.$fns),
+            is_crossder_zero_global($ms.$fns),
+        )
+    end
+    @eval function $ms.$fns(dx::D, dy::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        y = primal(dy)
+        p_out = $ms.$fns(x, y)
+        t_out = hessian_tracer_2_to_1(
+            tracer(dx),
+            tracer(dy),
+            is_firstder_arg1_zero_local($ms.$fns, x, y),
+            is_seconder_arg1_zero_local($ms.$fns, x, y),
+            is_firstder_arg2_zero_local($ms.$fns, x, y),
+            is_seconder_arg2_zero_local($ms.$fns, x, y),
+            is_crossder_zero_local($ms.$fns, x, y),
+        )
+        return Dual(p_out, t_out)
+    end
 
-        function $ms.$fns(tx::HessianTracer, y::Number)
-            return hessian_tracer_1_to_1(
-                tx,
-                is_firstder_arg1_zero_global($ms.$fns),
-                is_seconder_arg1_zero_global($ms.$fns),
-            )
-        end
-        function $ms.$fns(x::Number, ty::HessianTracer)
-            return hessian_tracer_1_to_1(
-                ty,
-                is_firstder_arg2_zero_global($ms.$fns),
-                is_seconder_arg2_zero_global($ms.$fns),
-            )
-        end
+    @eval function $ms.$fns(tx::HessianTracer, y::Number)
+        return hessian_tracer_1_to_1(
+            tx,
+            is_firstder_arg1_zero_global($ms.$fns),
+            is_seconder_arg1_zero_global($ms.$fns),
+        )
+    end
+    @eval function $ms.$fns(x::Number, ty::HessianTracer)
+        return hessian_tracer_1_to_1(
+            ty,
+            is_firstder_arg2_zero_global($ms.$fns),
+            is_seconder_arg2_zero_global($ms.$fns),
+        )
+    end
 
-        function $ms.$fns(dx::D, y::Number) where {P,T<:HessianTracer,D<:Dual{P,T}}
-            x = primal(dx)
-            p_out = $ms.$fns(x, y)
-            t_out = hessian_tracer_1_to_1(
-                tracer(dx),
-                is_firstder_arg1_zero_local($ms.$fns, x, y),
-                is_seconder_arg1_zero_local($ms.$fns, x, y),
-            )
-            return Dual(p_out, t_out)
-        end
-        function $ms.$fns(x::Number, dy::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
-            y = primal(dy)
-            p_out = $ms.$fns(x, y)
-            t_out = hessian_tracer_1_to_1(
-                tracer(dy),
-                is_firstder_arg2_zero_local($ms.$fns, x, y),
-                is_seconder_arg2_zero_local($ms.$fns, x, y),
-            )
-            return Dual(p_out, t_out)
-        end
+    @eval function $ms.$fns(dx::D, y::Number) where {P,T<:HessianTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        p_out = $ms.$fns(x, y)
+        t_out = hessian_tracer_1_to_1(
+            tracer(dx),
+            is_firstder_arg1_zero_local($ms.$fns, x, y),
+            is_seconder_arg1_zero_local($ms.$fns, x, y),
+        )
+        return Dual(p_out, t_out)
+    end
+    @eval function $ms.$fns(x::Number, dy::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
+        y = primal(dy)
+        p_out = $ms.$fns(x, y)
+        t_out = hessian_tracer_1_to_1(
+            tracer(dy),
+            is_firstder_arg2_zero_local($ms.$fns, x, y),
+            is_seconder_arg2_zero_local($ms.$fns, x, y),
+        )
+        return Dual(p_out, t_out)
     end
 end
 
@@ -156,29 +152,27 @@ end
 
 function overload_hessian_1_to_2(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
-    @eval begin
-        function $ms.$fns(t::HessianTracer)
-            return hessian_tracer_1_to_2(
-                t,
-                is_firstder_out1_zero_global($ms.$fns),
-                is_seconder_out1_zero_global($ms.$fns),
-                is_firstder_out2_zero_global($ms.$fns),
-                is_seconder_out2_zero_global($ms.$fns),
-            )
-        end
+    @eval function $ms.$fns(t::HessianTracer)
+        return hessian_tracer_1_to_2(
+            t,
+            is_firstder_out1_zero_global($ms.$fns),
+            is_seconder_out1_zero_global($ms.$fns),
+            is_firstder_out2_zero_global($ms.$fns),
+            is_seconder_out2_zero_global($ms.$fns),
+        )
+    end
 
-        function $ms.$fns(d::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
-            x = primal(d)
-            p1_out, p2_out = $ms.$fns(x)
-            t1_out, t2_out = hessian_tracer_1_to_2(
-                d,
-                is_firstder_out1_zero_local($ms.$fns, x),
-                is_seconder_out1_zero_local($ms.$fns, x),
-                is_firstder_out2_zero_local($ms.$fns, x),
-                is_seconder_out2_zero_local($ms.$fns, x),
-            )
-            return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))
-        end
+    @eval function $ms.$fns(d::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
+        x = primal(d)
+        p1_out, p2_out = $ms.$fns(x)
+        t1_out, t2_out = hessian_tracer_1_to_2(
+            d,
+            is_firstder_out1_zero_local($ms.$fns, x),
+            is_seconder_out1_zero_local($ms.$fns, x),
+            is_firstder_out2_zero_local($ms.$fns, x),
+            is_seconder_out2_zero_local($ms.$fns, x),
+        )
+        return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))
     end
 end
 


### PR DESCRIPTION
The rationale behind this PR is that we will want to add package extensions (for things like SpecialFunctions.jl), overloading functions that do not necessarily belong to `Base`.
The main changes are:
- I put the overloading mechanism into functions, so that these functions might be called in extensions with new operators
- I added a module argument so that the overloading works outside of `Base` too

It also fixes a few bugs, for which I added TODOs in the source code