### PR TITLE
Add influence classification for ConnectivityTracer

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -7,8 +7,6 @@ for TT in (GradientTracer, ConnectivityTracer, HessianTracer)
 
     Base.big(::Type{T})   where {T<:TT} = T
     Base.widen(::Type{T}) where {T<:TT} = T
-    Base.big(t::T)        where {T<:TT} = t
-    Base.widen(t::T)      where {T<:TT} = t
 
     Base.convert(::Type{T}, x::Number)   where {T<:TT} = empty(T)
     Base.convert(::Type{T}, t::T)        where {T<:TT} = t
@@ -26,17 +24,6 @@ for TT in (GradientTracer, ConnectivityTracer, HessianTracer)
     Base.floatmax(::Type{T})    where {T<:TT} = empty(T)
     Base.maxintfloat(::Type{T}) where {T<:TT} = empty(T)
     
-    Base.zero(::T)        where {T<:TT} = empty(T)
-    Base.one(::T)         where {T<:TT} = empty(T)
-    Base.oneunit(::T)     where {T<:TT} = empty(T)
-    Base.typemin(::T)     where {T<:TT} = empty(T)
-    Base.typemax(::T)     where {T<:TT} = empty(T)
-    Base.eps(::T)         where {T<:TT} = empty(T)
-    Base.float(::T)       where {T<:TT} = empty(T)
-    Base.floatmin(::T)    where {T<:TT} = empty(T)
-    Base.floatmax(::T)    where {T<:TT} = empty(T)
-    Base.maxintfloat(::T) where {T<:TT} = empty(T)
-
     ## Array constructors
     Base.similar(a::Array{T,1})                     where {T<:TT}   = zeros(T, size(a, 1))
     Base.similar(a::Array{T,2})                     where {T<:TT}   = zeros(T, size(a, 1), size(a, 2))
@@ -66,8 +53,6 @@ end
 
 Base.big(::Type{D})   where {P,T,D<:Dual{P,T}} = Dual{big(P),T}
 Base.widen(::Type{D}) where {P,T,D<:Dual{P,T}} = Dual{widen(P),T}
-Base.big(d::D)        where {P,T,D<:Dual{P,T}} = Dual(big(primal(d)),   tracer(d))
-Base.widen(d::D)      where {P,T,D<:Dual{P,T}} = Dual(widen(primal(d)), tracer(d))
 
 Base.convert(::Type{D}, x::Number) where {P,T,D<:Dual{P,T}}           = Dual(x, empty(T))
 Base.convert(::Type{D}, d::D)      where {P,T,D<:Dual{P,T}}           = d
@@ -88,17 +73,6 @@ Base.float(::Type{D})       where {P,T,D<:Dual{P,T}} = D(float(P),       empty(T
 Base.floatmin(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmin(P),    empty(T))
 Base.floatmax(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmax(P),    empty(T))
 Base.maxintfloat(::Type{D}) where {P,T,D<:Dual{P,T}} = D(maxintfloat(P), empty(T))
-
-Base.zero(d::D)        where {P,T,D<:Dual{P,T}} = D(zero(primal(d)),        empty(T))
-Base.one(d::D)         where {P,T,D<:Dual{P,T}} = D(one(primal(d)),         empty(T))
-Base.oneunit(d::D)     where {P,T,D<:Dual{P,T}} = D(oneunit(primal(d)),     empty(T))
-Base.typemin(d::D)     where {P,T,D<:Dual{P,T}} = D(typemin(primal(d)),     empty(T))
-Base.typemax(d::D)     where {P,T,D<:Dual{P,T}} = D(typemax(primal(d)),     empty(T))
-Base.eps(d::D)         where {P,T,D<:Dual{P,T}} = D(eps(primal(d)),         empty(T))
-Base.float(d::D)       where {P,T,D<:Dual{P,T}} = D(float(primal(d)),       empty(T))
-Base.floatmin(d::D)    where {P,T,D<:Dual{P,T}} = D(floatmin(primal(d)),    empty(T))
-Base.floatmax(d::D)    where {P,T,D<:Dual{P,T}} = D(floatmax(primal(d)),    empty(T))
-Base.maxintfloat(d::D) where {P,T,D<:Dual{P,T}} = D(maxintfloat(primal(d)), empty(T))
 
 ## Array constructors
 function Base.similar(a::Array{D,1}) where {P,T,D<:Dual{P,T}}

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -66,8 +66,11 @@ ops_1_to_1_f = (
     +, -,
     identity,
     abs, hypot,
-    deg2rad, rad2deg,
-    mod2pi, prevfloat, nextfloat,
+    # angles
+    deg2rad, rad2deg, mod2pi,
+    # floats
+    float, prevfloat, nextfloat,
+    big, widen,
 )
 for op in ops_1_to_1_f
     T = typeof(op)
@@ -98,8 +101,7 @@ end
 ops_1_to_1_i = (
     zero, one, oneunit,
     typemin, typemax, eps,
-    float, floatmin, floatmax, maxintfloat,
-    big, widen,
+    floatmin, floatmax, maxintfloat,
 )
 for op in ops_1_to_1_i
     T = typeof(op)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,7 +1,8 @@
 ## Operator definitions
 
 # We use a system of letters to categorize operators:
-#   z: first- and second-order derivatives (FOD, SOD) are zero
+#   i: independence - no influence at all
+#   z: influence but first- and second-order derivatives (FOD, SOD) are zero
 #   f: FOD ∂f/∂x is non-zero, SOD ∂²f/∂x² is zero 
 #   s: FOD ∂f/∂x is non-zero, SOD ∂²f/∂x² is non-zero
 #   c: Cross-derivative ∂²f/∂x∂y is non-zero
@@ -11,14 +12,17 @@
 ##=================================#
 # Operators for functions f: ℝ → ℝ #
 #==================================#
+function is_influence_zero_global end
 function is_firstder_zero_global end
 function is_seconder_zero_global end
 
 # Fallbacks for local derivatives:
+is_influence_zero_local(f::F, x) where {F} = is_influence_zero_global(f)
 is_firstder_zero_local(f::F, x) where {F} = is_firstder_zero_global(f)
 is_seconder_zero_local(f::F, x) where {F} = is_seconder_zero_global(f)
 
 # ops_1_to_1_s: 
+# x -> f  != 0
 # ∂f/∂x   != 0
 # ∂²f/∂x² != 0
 ops_1_to_1_s = (
@@ -49,11 +53,13 @@ ops_1_to_1_s = (
 )
 for op in ops_1_to_1_s
     T = typeof(op)
+    @eval is_influence_zero_global(::$T) = false
     @eval is_firstder_zero_global(::$T) = false
     @eval is_seconder_zero_global(::$T) = false
 end
 
 # ops_1_to_1_f:
+# x -> f  != 0
 # ∂f/∂x   != 0
 # ∂²f/∂x² == 0
 ops_1_to_1_f = (
@@ -65,11 +71,13 @@ ops_1_to_1_f = (
 )
 for op in ops_1_to_1_f
     T = typeof(op)
+    @eval is_influence_zero_global(::$T) = false
     @eval is_firstder_zero_global(::$T) = false
     @eval is_seconder_zero_global(::$T) = true
 end
 
 # ops_1_to_1_z:
+# x -> f  != 0
 # ∂f/∂x   == 0
 # ∂²f/∂x² == 0
 ops_1_to_1_z = (
@@ -78,6 +86,24 @@ ops_1_to_1_z = (
 )
 for op in ops_1_to_1_z
     T = typeof(op)
+    @eval is_influence_zero_global(::$T) = false
+    @eval is_firstder_zero_global(::$T) = true
+    @eval is_seconder_zero_global(::$T) = true
+end
+
+# ops_1_to_1_i:
+# x -> f  == 0
+# ∂f/∂x   == 0
+# ∂²f/∂x² == 0
+ops_1_to_1_i = (
+    zero, one, oneunit,
+    typemin, typemax, eps,
+    float, floatmin, floatmax, maxintfloat,
+    big, widen,
+)
+for op in ops_1_to_1_i
+    T = typeof(op)
+    @eval is_influence_zero_global(::$T) = true
     @eval is_firstder_zero_global(::$T) = true
     @eval is_seconder_zero_global(::$T) = true
 end
@@ -86,12 +112,15 @@ ops_1_to_1 = union(
     ops_1_to_1_s, 
     ops_1_to_1_f, 
     ops_1_to_1_z,
+    ops_1_to_1_i,
 )
 
 ##==================================#
 # Operators for functions f: ℝ² → ℝ #
 #===================================#
 
+function is_influence_arg1_zero_global end
+function is_influence_arg2_zero_global end
 function is_firstder_arg1_zero_global end
 function is_seconder_arg1_zero_global end
 function is_firstder_arg2_zero_global end
@@ -99,13 +128,15 @@ function is_seconder_arg2_zero_global end
 function is_crossder_zero_global end
 
 # Fallbacks for local derivatives:
+is_influence_arg1_zero_local(f::F, x, y) where {F} = is_influence_arg1_zero_global(f)
+is_influence_arg2_zero_local(f::F, x, y) where {F} = is_influence_arg2_zero_global(f)
 is_firstder_arg1_zero_local(f::F, x, y) where {F} = is_firstder_arg1_zero_global(f)
 is_seconder_arg1_zero_local(f::F, x, y) where {F} = is_seconder_arg1_zero_global(f)
 is_firstder_arg2_zero_local(f::F, x, y) where {F} = is_firstder_arg2_zero_global(f)
 is_seconder_arg2_zero_local(f::F, x, y) where {F} = is_seconder_arg2_zero_global(f)
 is_crossder_zero_local(f::F, x, y) where {F}      = is_crossder_zero_global(f)
 
-# ops_2_to_1_ssc: 
+# ops_2_to_1_ssc:
 # ∂f/∂x    != 0
 # ∂²f/∂x²  != 0
 # ∂f/∂y    != 0
@@ -116,6 +147,8 @@ ops_2_to_1_ssc = (
 )
 for op in ops_2_to_1_ssc
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -133,6 +166,8 @@ ops_2_to_1_ssz = ()
 #=
 for op in ops_2_to_1_ssz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -151,6 +186,8 @@ ops_2_to_1_sfc = ()
 #=
 for op in ops_2_to_1_sfc
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -169,6 +206,8 @@ ops_2_to_1_sfz = ()
 #=
 for op in ops_2_to_1_sfz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -189,6 +228,8 @@ ops_2_to_1_fsc = (
 )
 for op in ops_2_to_1_fsc
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -209,6 +250,8 @@ ops_2_to_1_fsz = ()
 #=
 for op in ops_2_to_1_fsz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -228,6 +271,8 @@ ops_2_to_1_ffc = (
 )
 for op in ops_2_to_1_ffc
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -252,6 +297,8 @@ ops_2_to_1_ffz = (
 )
 for op in ops_2_to_1_ffz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -277,6 +324,8 @@ ops_2_to_1_szz = ()
 #=
 for op in ops_2_to_1_szz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = false
     @eval is_firstder_arg2_zero_global(::$T) = true
@@ -295,6 +344,8 @@ ops_2_to_1_zsz = ()
 #=
 for op in ops_2_to_1_zsz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = true
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -314,6 +365,8 @@ ops_2_to_1_fzz = (
 )
 for op in ops_2_to_1_fzz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = false
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = true
@@ -331,6 +384,8 @@ ops_2_to_1_zfz = ()
 #=
 for op in ops_2_to_1_zfz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = true
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = false
@@ -351,6 +406,8 @@ ops_2_to_1_zzz = (
 )
 for op in ops_2_to_1_zzz
     T = typeof(op)
+    @eval is_influence_arg1_zero_global(::$T) = false
+    @eval is_influence_arg2_zero_global(::$T) = false
     @eval is_firstder_arg1_zero_global(::$T) = true
     @eval is_seconder_arg1_zero_global(::$T) = true
     @eval is_firstder_arg2_zero_global(::$T) = true
@@ -385,14 +442,18 @@ ops_2_to_1 = union(
 # Operators for functions f: ℝ → ℝ² #
 #===================================#
 
+function is_influence_out1_zero_global end
+function is_influence_out2_zero_global end
 function is_firstder_out1_zero_global end
 function is_seconder_out1_zero_global end
 function is_firstder_out2_zero_global end
 function is_seconder_out2_zero_global end
 
 # Fallbacks for local derivatives:
-is_seconder_out1_zero_local(f::F, x) where {F} = is_seconder_out1_zero_global(f)
+is_influence_out1_zero_local(f::F, x) where {F} = is_influence_out1_zero_global(f)
+is_influence_out2_zero_local(f::F, x) where {F} = is_influence_out2_zero_global(f)
 is_firstder_out1_zero_local(f::F, x) where {F} = is_firstder_out1_zero_global(f)
+is_seconder_out1_zero_local(f::F, x) where {F} = is_seconder_out1_zero_global(f)
 is_firstder_out2_zero_local(f::F, x) where {F} = is_firstder_out2_zero_global(f)
 is_seconder_out2_zero_local(f::F, x) where {F} = is_seconder_out2_zero_global(f)
 
@@ -408,6 +469,8 @@ ops_1_to_2_ss = (
 )
 for op in ops_1_to_2_ss
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = false
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -423,6 +486,8 @@ ops_1_to_2_sf = ()
 #=
 for op in ops_1_to_2_sf
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = false
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -439,6 +504,8 @@ ops_1_to_2_sz = ()
 #=
 for op in ops_1_to_2_sz
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = false
     @eval is_firstder_out2_zero_global(::$T) = true
@@ -455,6 +522,8 @@ ops_1_to_2_fs = ()
 #=
 for op in ops_1_to_2_fs
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -471,6 +540,8 @@ ops_1_to_2_ff = ()
 #=
 for op in ops_1_to_2_ff
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -489,6 +560,8 @@ ops_1_to_2_fz = (
 #=
 for op in ops_1_to_2_fz
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = false
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = true
@@ -505,6 +578,8 @@ ops_1_to_2_zs = ()
 #=
 for op in ops_1_to_2_zs
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = true
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -521,6 +596,8 @@ ops_1_to_2_zf = ()
 #=
 for op in ops_1_to_2_zf
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = true
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = false
@@ -537,6 +614,8 @@ ops_1_to_2_zz = ()
 #=
 for op in ops_1_to_2_zz
     T = typeof(op)
+    @eval is_influence_out1_zero_global(::$T) = false
+    @eval is_influence_out2_zero_global(::$T) = false
     @eval is_firstder_out1_zero_global(::$T) = true
     @eval is_seconder_out1_zero_global(::$T) = true
     @eval is_firstder_out2_zero_global(::$T) = true

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -1,33 +1,112 @@
 ## 1-to-1
+function connectivity_tracer_1_to_1(
+    t::T, is_influence_zero::Bool
+) where {T<:ConnectivityTracer}
+    if is_influence_zero
+        return empty(T)
+    else
+        return t
+    end
+end
+
 for fn in nameof.(ops_1_to_1)
-    @eval Base.$fn(t::ConnectivityTracer) = t
+    @eval function Base.$fn(t::T) where {T<:ConnectivityTracer}
+        return connectivity_tracer_1_to_1(t, is_influence_zero_global($fn))
+    end
     @eval function Base.$fn(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
-        return Dual($fn(primal(d)), tracer(d))
+        x = primal(d)
+        p_out = Base.$fn(x)
+        t_out = connectivity_tracer_1_to_1(tracer(d), is_influence_zero_local($fn, x))
+        return Dual(p_out, t_out)
     end
 end
 
 ## 2-to-1
+function connectivity_tracer_2_to_1(
+    tx::T, ty::T, is_influence_arg1_zero::Bool, is_influence_arg2_zero::Bool
+) where {T<:ConnectivityTracer}
+    if is_influence_arg1_zero
+        if is_influence_arg2_zero
+            return empty(T)
+        else
+            return ty
+        end
+    else # ∂f∂x ≠ 0 
+        if is_influence_arg2_zero
+            return tx
+        else
+            return T(inputs(tx) ∪ inputs(ty))
+        end
+    end
+end
+
 for fn in nameof.(ops_2_to_1)
-    @eval Base.$fn(a::T, b::T) where {T<:ConnectivityTracer} = T(inputs(a) ∪ inputs(b))
-    @eval function Base.$fn(da::D, db::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
-        return Dual($fn(primal(da), primal(db)), $fn(tracer(da), tracer(db)))
+    @eval function Base.$fn(tx::T, ty::T) where {T<:ConnectivityTracer}
+        return connectivity_tracer_2_to_1(
+            tx, ty, is_influence_arg1_zero_global($fn), is_influence_arg2_zero_global($fn)
+        )
+    end
+    @eval function Base.$fn(dx::D, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        y = primal(dy)
+        p_out = Base.$fn(x, y)
+        t_out = connectivity_tracer_2_to_1(
+            tracer(dx),
+            tracer(dy),
+            is_influence_arg1_zero_local($fn, x, y),
+            is_influence_arg2_zero_local($fn, x, y),
+        )
+        return Dual(p_out, t_out)
     end
 
-    @eval Base.$fn(t::ConnectivityTracer, ::Number) = t
-    @eval Base.$fn(dx::D, y::Number) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-        Dual($fn(primal(dx), y), tracer(dx))
+    @eval function Base.$fn(tx::ConnectivityTracer, ::Number)
+        return connectivity_tracer_1_to_1(tx, is_influence_arg1_zero_global($fn))
+    end
+    @eval function Base.$fn(dx::D, y::Number) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
+        x = primal(dx)
+        p_out = Base.$fn(x, y)
+        t_out = connectivity_tracer_1_to_1(
+            tracer(dx), is_influence_arg1_zero_local($fn, x, y)
+        )
+        return Dual(p_out, t_out)
+    end
 
-    @eval Base.$fn(::Number, t::ConnectivityTracer) = t
-    @eval Base.$fn(x::Number, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}} =
-        Dual($fn(x, primal(dy)), tracer(dy))
+    @eval function Base.$fn(::Number, ty::ConnectivityTracer)
+        return connectivity_tracer_1_to_1(ty, is_influence_arg2_zero_global($fn))
+    end
+    @eval function Base.$fn(x::Number, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
+        y = primal(dy)
+        p_out = Base.$fn(x, y)
+        t_out = connectivity_tracer_1_to_1(
+            tracer(dy), is_influence_arg2_zero_local($fn, x, y)
+        )
+        return Dual(p_out, t_out)
+    end
 end
 
 ## 1-to-2
+function connectivity_tracer_1_to_2(
+    t::T, is_influence_out1_zero::Bool, is_influence_out2_zero::Bool
+) where {T<:ConnectivityTracer}
+    t1 = connectivity_tracer_1_to_1(t, is_influence_out1_zero)
+    t2 = connectivity_tracer_1_to_1(t, is_influence_out2_zero)
+    return (t1, t2)
+end
+
 for fn in nameof.(ops_1_to_2)
-    @eval Base.$fn(t::ConnectivityTracer) = (t, t)
+    @eval function Base.$fn(t::ConnectivityTracer)
+        return connectivity_tracer_1_to_2(
+            t, is_influence_out1_zero_global($fn), is_influence_out2_zero_global($fn)
+        )
+    end
+
     @eval function Base.$fn(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
-        p1, p2 = $fn(primal(d))
-        return (Dual(p1, tracer(d)), Dual(p2, tracer(d)))
+        x = primal(d)
+        p1_out, p2_out = Base.$fn(x)
+        t1_out, t2_out = connectivity_tracer_1_to_2(
+            t, is_influence_out1_zero_local($fn, x), is_influence_out2_zero_local($fn, x)
+        )
+        return (Dual(p1_out, t1_out), Dual(p1_out, t1_out))
     end
 end
 

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -13,12 +13,12 @@ end
 function overload_connectivity_1_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
     @eval function $ms.$fns(t::T) where {T<:ConnectivityTracer}
-        return connectivity_tracer_1_to_1(t, is_influence_zero_global($fns))
+        return connectivity_tracer_1_to_1(t, is_influence_zero_global($ms.$fns))
     end
     @eval function $ms.$fns(d::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
         x = primal(d)
         p_out = $ms.$fns(x)
-        t_out = connectivity_tracer_1_to_1(tracer(d), is_influence_zero_local($fns, x))
+        t_out = connectivity_tracer_1_to_1(tracer(d), is_influence_zero_local($ms.$fns, x))
         return Dual(p_out, t_out)
     end
 end
@@ -43,11 +43,14 @@ function connectivity_tracer_2_to_1(
     end
 end
 
-function overload_connectivity_1_to_2(m::Module, fn::Function)
+function overload_connectivity_2_to_1(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
     @eval function $ms.$fns(tx::T, ty::T) where {T<:ConnectivityTracer}
         return connectivity_tracer_2_to_1(
-            tx, ty, is_influence_arg1_zero_global($fns), is_influence_arg2_zero_global($fns)
+            tx,
+            ty,
+            is_influence_arg1_zero_global($ms.$fns),
+            is_influence_arg2_zero_global($ms.$fns),
         )
     end
     @eval function $ms.$fns(dx::D, dy::D) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
@@ -57,8 +60,8 @@ function overload_connectivity_1_to_2(m::Module, fn::Function)
         t_out = connectivity_tracer_2_to_1(
             tracer(dx),
             tracer(dy),
-            is_influence_arg1_zero_local($fns, x, y),
-            is_influence_arg2_zero_local($fns, x, y),
+            is_influence_arg1_zero_local($ms.$fns, x, y),
+            is_influence_arg2_zero_local($ms.$fns, x, y),
         )
         return Dual(p_out, t_out)
     end
@@ -70,7 +73,7 @@ function overload_connectivity_1_to_2(m::Module, fn::Function)
         x = primal(dx)
         p_out = $ms.$fns(x, y)
         t_out = connectivity_tracer_1_to_1(
-            tracer(dx), is_influence_arg1_zero_local($fns, x, y)
+            tracer(dx), is_influence_arg1_zero_local($ms.$fns, x, y)
         )
         return Dual(p_out, t_out)
     end
@@ -82,7 +85,7 @@ function overload_connectivity_1_to_2(m::Module, fn::Function)
         y = primal(dy)
         p_out = $ms.$fns(x, y)
         t_out = connectivity_tracer_1_to_1(
-            tracer(dy), is_influence_arg2_zero_local($fns, x, y)
+            tracer(dy), is_influence_arg2_zero_local($ms.$fns, x, y)
         )
         return Dual(p_out, t_out)
     end
@@ -102,7 +105,9 @@ function overload_connectivity_1_to_2(m::Module, fn::Function)
     ms, fns = nameof(m), nameof(fn)
     @eval function $ms.$fns(t::ConnectivityTracer)
         return connectivity_tracer_1_to_2(
-            t, is_influence_out1_zero_global($fns), is_influence_out2_zero_global($fns)
+            t,
+            is_influence_out1_zero_global($ms.$fns),
+            is_influence_out2_zero_global($ms.$fns),
         )
     end
 
@@ -110,7 +115,9 @@ function overload_connectivity_1_to_2(m::Module, fn::Function)
         x = primal(d)
         p1_out, p2_out = $ms.$fns(x)
         t1_out, t2_out = connectivity_tracer_1_to_2(
-            t, is_influence_out1_zero_local($fns, x), is_influence_out2_zero_local($fns, x)
+            t,
+            is_influence_out1_zero_local($ms.$fns, x),
+            is_influence_out2_zero_local($ms.$fns, x),
         )
         return (Dual(p1_out, t1_out), Dual(p2_out, t2_out))
     end

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -34,7 +34,7 @@ function connectivity_tracer_2_to_1(
         else
             return ty
         end
-    else # ∂f∂x ≠ 0 
+    else # x -> f ≠ 0 
         if is_influence_arg2_zero
             return tx
         else

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -41,19 +41,35 @@ random_input(::typeof(sincosd)) = 180 * rand()
 random_first_input(op) = random_input(op)
 random_second_input(op) = random_input(op)
 
+## Derivatives and special cases
+
+both_derivatives_1_to_1(op, x) = derivative(op, x), second_derivative(op, x)
+
+function both_derivatives_1_to_1(::Union{typeof(big),typeof(widen)}, x)
+    return both_derivatives_1_to_1(identity, x)
+end
+function both_derivatives_1_to_1(
+    ::Union{typeof(floatmin),typeof(floatmax),typeof(maxintfloat)}, x
+)
+    return both_derivatives_1_to_1(zero, x)
+end
+
+function both_derivatives_2_to_1(op, x, y)
+    return gradient(Base.splat(op), [x, y]), hessian(Base.splat(op), [x, y])
+end
+
+function both_derivatives_1_to_2(op, x)
+    function op_vec(x)
+        y = op(x)
+        return [y[1], y[2]]
+    end
+    return derivative(op_vec, x), second_derivative(op_vec, x)
+end
+
 ## 1-to-1
 
 function correct_classification_1_to_1(op, x; atol)
-    dfdx, d²fdx² = try
-        derivative(op, x), second_derivative(op, x)
-    catch e
-        if e isa MethodError
-            # ForwardDiff can't handle this operator: assume it has zero derivatives
-            0.0, 0.0
-        else
-            throw(e)
-        end
-    end
+    dfdx, d²fdx² = both_derivatives_1_to_1(op, x)
     if (is_firstder_zero_global(op) | is_firstder_zero_local(op, x)) &&
         !isapprox(dfdx, 0; atol)
         return false
@@ -77,16 +93,7 @@ end;
 ## 2-to-1
 
 function correct_classification_2_to_1(op, x, y; atol)
-    g, H = try
-        gradient(Base.splat(op), [x, y]), hessian(Base.splat(op), [x, y])
-    catch e
-        if e isa MethodError
-            # ForwardDiff can't handle this operator: assume it has zero derivatives
-            zeros(2), zeros(2, 2)
-        else
-            throw(e)
-        end
-    end
+    g, H = both_derivatives_2_to_1(op, x, y)
 
     ∂f∂x    = g[1]
     ∂f∂y    = g[2]
@@ -127,21 +134,7 @@ end;
 ## 1-to-2
 
 function correct_classification_1_to_2(op, x; atol)
-    function op_vec(x)
-        y = op(x)
-        return [y[1], y[2]]
-    end
-
-    d1, d2 = try
-        derivative(op_vec, x), second_derivative(op_vec, x)
-    catch e
-        if e isa MethodError
-            # ForwardDiff can't handle this operator: assume it has zero derivatives
-            zeros(2), zeros(2)
-        else
-            throw(e)
-        end
-    end
+    d1, d2 = both_derivatives_1_to_2(op, x)
 
     ∂f₁∂x = d1[1]
     ∂f₂∂x = d1[2]


### PR DESCRIPTION
- Revamp `ConnectivityTracer` to follow the blueprint of `GradientTracer`, except that it uses `is_influence` instead of `is_firstder`
- Add a new category of operators whose influence is zero, and distinguish them from those who have an influence but zero derivatives
- Handle `big`, `widen`, `zero`, `one`, `oneunit`, `typemin`, `typemax`, `eps`, `float`, `floatmin`, `floatmax`, `maxintfloat` like normal `1_to_1` operators _when they are applied to numbers_ (not when they are applied to types)
- Add special case for when ForwardDiff cannot compute derivatives (we assume those derivatives are zero)