### PR TITLE
Make `AbstractTracer` subtype of `Real`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.4.1"
+version = "0.5.0-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,7 +54,7 @@ local_hessian_pattern
 !!! warning
     Internals may change without warning in a future release of SparseConnectivityTracer.
 
-SparseConnectivityTracer works by pushing `Number` types called tracers through generic functions.
+SparseConnectivityTracer works by pushing `Real` number types called tracers through generic functions.
 Currently, three tracer types are provided:
 
 ```@docs

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -142,8 +142,7 @@ end
 ## Special cases
 
 ## Exponent (requires extra types)
-
-for S in (Real, Integer, Rational, Irrational{:ℯ})
+for S in (Real, Integer, Rational, Complex, Irrational{:ℯ})
     Base.:^(t::ConnectivityTracer, ::S) = t
     function Base.:^(dx::D, y::S) where {P,T<:ConnectivityTracer,D<:Dual{P,T}}
         return Dual(primal(dx)^y, tracer(dx))

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -136,8 +136,7 @@ end
 ## Special cases
 
 ## Exponent (requires extra types)
-
-for S in (Real, Integer, Rational, Irrational{:ℯ})
+for S in (Real, Integer, Rational, Complex, Irrational{:ℯ})
     Base.:^(t::GradientTracer, ::S) = t
     Base.:^(::S, t::GradientTracer) = t
 

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -187,7 +187,7 @@ end
 ## Special cases
 
 ## Exponent (requires extra types)
-for S in (Real, Integer, Rational, Irrational{:ℯ})
+for S in (Real, Integer, Rational, Complex, Irrational{:ℯ})
     function Base.:^(tx::T, y::S) where {T<:HessianTracer}
         return T(gradient(tx), hessian(tx) ∪ (gradient(tx) × gradient(tx)))
     end

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -1,4 +1,4 @@
-abstract type AbstractTracer <: Number end
+abstract type AbstractTracer <: Real end
 
 # Convenience constructor for empty tracers
 empty(tracer::T) where {T<:AbstractTracer} = empty(T)
@@ -19,7 +19,7 @@ sparse_vector(T, index) = T([index])
 """
 $(TYPEDEF)
 
-`Number` type keeping track of input indices of previous computations.
+`Real` number type keeping track of input indices of previous computations.
 
 For a higher-level interface, refer to [`connectivity_pattern`](@ref).
 
@@ -72,7 +72,7 @@ ConnectivityTracer(t::ConnectivityTracer) = t
 """
 $(TYPEDEF)
 
-`Number` type keeping track of non-zero gradient entries.
+`Real` number type keeping track of non-zero gradient entries.
 
 For a higher-level interface, refer to [`jacobian_pattern`](@ref).
 
@@ -121,7 +121,7 @@ GradientTracer(t::GradientTracer) = t
 """
 $(TYPEDEF)
 
-`Number` type keeping track of non-zero gradient and Hessian entries.
+`Real` number type keeping track of non-zero gradient and Hessian entries.
 
 For a higher-level interface, refer to [`hessian_pattern`](@ref).
 


### PR DESCRIPTION
Make `AbstractTracer` subtype of `Real` instead of `Number`. Closes #91.

Not sure whether we need to consider this as breaking, since tracer types are considered internals. However, the documentation mentioned tracers subtyping `Number`.