### PR TITLE
Support Hessians on non-tracer outputs

### DIFF
--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -391,7 +391,7 @@ function hessian_pattern_to_mat(
 end
 
 function hessian_pattern_to_mat(xt::AbstractArray{T}, yt::Number) where {T<:HessianTracer}
-    return hessian_pattern_to_mat(tracer.(xt), empty(T))
+    return hessian_pattern_to_mat(xt, empty(T))
 end
 
 function hessian_pattern_to_mat(

--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -389,3 +389,13 @@ function hessian_pattern_to_mat(
 ) where {P1,P2,T<:HessianTracer,D1<:Dual{P1,T},D2<:Dual{P2,T}}
     return hessian_pattern_to_mat(tracer.(xt), tracer(yt))
 end
+
+function hessian_pattern_to_mat(xt::AbstractArray{T}, yt::Number) where {T<:HessianTracer}
+    return hessian_pattern_to_mat(tracer.(xt), empty(T))
+end
+
+function hessian_pattern_to_mat(
+    xt::AbstractArray{D1}, yt::Number
+) where {P1,T<:HessianTracer,D1<:Dual{P1,T}}
+    return hessian_pattern_to_mat(tracer.(xt), empty(T))
+end

--- a/test/test_connectivity.jl
+++ b/test/test_connectivity.jl
@@ -62,6 +62,7 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
         @test connectivity_pattern(x -> x^ℯ, 1, G) ≈ [1;;]
         @test connectivity_pattern(x -> ℯ^x, 1, G) ≈ [1;;]
         @test connectivity_pattern(x -> round(x, RoundNearestTiesUp), 1, G) ≈ [1;;]
+        @test connectivity_pattern(x -> 0, 1, G) ≈ [0;;]
 
         # SpecialFunctions extension
         @test connectivity_pattern(x -> erf(x[1]), rand(2), G) == [1 0]
@@ -87,5 +88,6 @@ end
         @test local_connectivity_pattern(
             x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 3 2 4], G
         ) == [0 0 1 1]
+        @test local_connectivity_pattern(x -> 0, 1, G) ≈ [0;;]
     end
 end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -62,6 +62,7 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
         @test jacobian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test jacobian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test jacobian_sparsity(x -> round(x, RoundNearestTiesUp), 1, method) ≈ [0;;]
+        @test jacobian_sparsity(x -> 0, 1, method) ≈ [0;;]
 
         # Linear Algebra
         @test jacobian_sparsity(x -> dot(x[1:2], x[4:5]), rand(5), method) == [1 1 0 1 1]
@@ -128,6 +129,7 @@ end
         @test jacobian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test jacobian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test jacobian_sparsity(x -> round(x, RoundNearestTiesUp), 1, method) ≈ [0;;]
+        @test jacobian_sparsity(x -> 0, 1, method) ≈ [0;;]
 
         # Linear algebra
         @test jacobian_sparsity(logdet, [1.0 -1.0; 2.0 2.0], method) == [1 1 1 1]  # (#68)

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -41,6 +41,7 @@ const SECOND_ORDER_SET_TYPES = (
         @test hessian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> round(x, RoundNearestTiesUp), 1, method) ≈ [0;;]
+        @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
 
         h = hessian_sparsity(x -> x[1] / x[2] + x[3] / 1 + 1 / x[4], rand(4), method)
         @test h == [
@@ -211,5 +212,6 @@ end
         @test hessian_sparsity(x -> (2//3)^x, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
+        @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
     end
 end


### PR DESCRIPTION
Fix #98 by adding the appropriate methods for converting Hessian tracers to a matrix when the output is not a tracer or dual

Add connectivity, gradient and Hessian tests for `f(x) = 0`