### PR TITLE
Constrain type of primal value in `Dual`

### DIFF
--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -200,7 +200,18 @@ struct Dual{P<:Number,T<:Union{ConnectivityTracer,GradientTracer,HessianTracer}}
        AbstractTracer
     primal::P
     tracer::T
+
+    function Dual{P,T}(
+        primal::P, tracer::T
+    ) where {P<:Number,T<:Union{ConnectivityTracer,GradientTracer,HessianTracer}}
+        if P <: AbstractTracer
+            error("Primal value of Dual tracer can't be an AbstractTracer.")
+        end
+        return new{P,T}(primal, tracer)
+    end
 end
+Dual(primal::P, tracer::T) where {P,T} = Dual{P,T}(primal, tracer)
+
 # TODO: support ConnectivityTracer
 
 primal(d::Dual) = d.primal

--- a/test/test_connectivity.jl
+++ b/test/test_connectivity.jl
@@ -1,6 +1,6 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer:
-    ConnectivityTracer, MissingPrimalError, tracer, trace_input, empty
+    ConnectivityTracer, Dual, MissingPrimalError, tracer, trace_input, empty
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using LinearAlgebra: det, dot, logdet
 using SpecialFunctions: erf, beta
@@ -40,54 +40,59 @@ NNLIB_ACTIVATIONS_F = (
 NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
 
 @testset "Connectivity Global" begin
-    @testset "Set type $G" for G in FIRST_ORDER_SET_TYPES
+    @testset "Set type $S" for S in FIRST_ORDER_SET_TYPES
         A = rand(1, 3)
-        @test connectivity_pattern(x -> only(A * x), rand(3), G) == [1 1 1]
+        @test connectivity_pattern(x -> only(A * x), rand(3), S) == [1 1 1]
 
         f(x) = [x[1]^2, 2 * x[1] * x[2]^2, sin(x[3])]
-        @test connectivity_pattern(f, rand(3), G) == [1 0 0; 1 1 0; 0 0 1]
-        @test connectivity_pattern(identity, rand(), G) ≈ [1;;]
-        @test connectivity_pattern(Returns(1), 1, G) ≈ [0;;]
+        @test connectivity_pattern(f, rand(3), S) == [1 0 0; 1 1 0; 0 0 1]
+        @test connectivity_pattern(identity, rand(), S) ≈ [1;;]
+        @test connectivity_pattern(Returns(1), 1, S) ≈ [0;;]
 
         # Test ConnectivityTracer on functions with zero derivatives
         x = rand(2)
         g(x) = [x[1] * x[2], ceil(x[1] * x[2]), x[1] * round(x[2])]
-        @test connectivity_pattern(g, x, G) == [1 1; 1 1; 1 1]
+        @test connectivity_pattern(g, x, S) == [1 1; 1 1; 1 1]
 
         # Code coverage
-        @test connectivity_pattern(x -> [sincos(x)...], 1, G) ≈ [1; 1]
-        @test connectivity_pattern(typemax, 1, G) ≈ [0;;]
-        @test connectivity_pattern(x -> x^(2//3), 1, G) ≈ [1;;]
-        @test connectivity_pattern(x -> (2//3)^x, 1, G) ≈ [1;;]
-        @test connectivity_pattern(x -> x^ℯ, 1, G) ≈ [1;;]
-        @test connectivity_pattern(x -> ℯ^x, 1, G) ≈ [1;;]
-        @test connectivity_pattern(x -> round(x, RoundNearestTiesUp), 1, G) ≈ [1;;]
-        @test connectivity_pattern(x -> 0, 1, G) ≈ [0;;]
+        @test connectivity_pattern(x -> [sincos(x)...], 1, S) ≈ [1; 1]
+        @test connectivity_pattern(typemax, 1, S) ≈ [0;;]
+        @test connectivity_pattern(x -> x^(2//3), 1, S) ≈ [1;;]
+        @test connectivity_pattern(x -> (2//3)^x, 1, S) ≈ [1;;]
+        @test connectivity_pattern(x -> x^ℯ, 1, S) ≈ [1;;]
+        @test connectivity_pattern(x -> ℯ^x, 1, S) ≈ [1;;]
+        @test connectivity_pattern(x -> round(x, RoundNearestTiesUp), 1, S) ≈ [1;;]
+        @test connectivity_pattern(x -> 0, 1, S) ≈ [0;;]
 
         # SpecialFunctions extension
-        @test connectivity_pattern(x -> erf(x[1]), rand(2), G) == [1 0]
-        @test connectivity_pattern(x -> beta(x[1], x[2]), rand(3), G) == [1 1 0]
+        @test connectivity_pattern(x -> erf(x[1]), rand(2), S) == [1 0]
+        @test connectivity_pattern(x -> beta(x[1], x[2]), rand(3), S) == [1 1 0]
 
         # NNlib extension
         for f in NNLIB_ACTIVATIONS
-            @test connectivity_pattern(f, 1, G) ≈ [1;;]
+            @test connectivity_pattern(f, 1, S) ≈ [1;;]
         end
 
         # Error handling when applying non-dual tracers to "local" functions with control flow
         @test_throws MissingPrimalError connectivity_pattern(
-            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 2 3 4], G
+            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 2 3 4], S
         ) == [1 1 0 0]
     end
 end
 
 @testset "Connectivity Local" begin
-    @testset "Set type $G" for G in FIRST_ORDER_SET_TYPES
+    @testset "Set type $S" for S in FIRST_ORDER_SET_TYPES
         @test local_connectivity_pattern(
-            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 2 3 4], G
+            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 2 3 4], S
         ) == [1 1 0 0]
         @test local_connectivity_pattern(
-            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 3 2 4], G
+            x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 3 2 4], S
         ) == [0 0 1 1]
-        @test local_connectivity_pattern(x -> 0, 1, G) ≈ [0;;]
+        @test local_connectivity_pattern(x -> 0, 1, S) ≈ [0;;]
+
+        # Putting Duals into Duals is prohibited
+        C = empty(ConnectivityTracer{S})
+        D1 = Dual(1.0, C)
+        @test_throws ErrorException D2 = Dual(D1, C)
     end
 end

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -21,10 +21,10 @@ const SECOND_ORDER_SET_TYPES = (
         ]
     end
 
-    @testset "Set type $G" for G in SECOND_ORDER_SET_TYPES
-        I = eltype(G)
+    @testset "Set type $S" for S in SECOND_ORDER_SET_TYPES
+        I = eltype(S)
         H = Set{Tuple{I,I}}
-        method = TracerSparsityDetector(G, H)
+        method = TracerSparsityDetector(S, H)
 
         @test hessian_sparsity(identity, rand(), method) ≈ [0;;]
         @test hessian_sparsity(sqrt, rand(), method) ≈ [1;;]
@@ -165,10 +165,10 @@ const SECOND_ORDER_SET_TYPES = (
 end
 
 @testset "Local Hessian" begin
-    @testset "Set type $G" for G in SECOND_ORDER_SET_TYPES
-        I = eltype(G)
+    @testset "Set type $S" for S in SECOND_ORDER_SET_TYPES
+        I = eltype(S)
         H = Set{Tuple{I,I}}
-        method = TracerLocalSparsityDetector(G, H)
+        method = TracerLocalSparsityDetector(S, H)
 
         f1(x) = x[1] + x[2] * x[3] + 1 / x[4] + x[2] * max(x[1], x[5])
         h = hessian_sparsity(f1, [1.0 3.0 5.0 1.0 2.0], method)
@@ -213,5 +213,10 @@ end
         @test hessian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
+
+        # Putting Duals into Duals is prohibited
+        H = empty(HessianTracer{S,Set{Tuple{Int,Int}}})
+        D1 = Dual(1.0, H)
+        @test_throws ErrorException D2 = Dual(D1, H)
     end
 end


### PR DESCRIPTION
The `primal` of a `Dual` tracer should never be a tracer itself. 
This will lead to a more informative error in #100.