### PR TITLE
Restructure benchmarks, add Hessian test cases

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,8 +1,13 @@
 name: Run benchmarks
 on:
   pull_request:
+    # Only trigger the benchmark job when you add `run benchmark` label to the PR
     types: [labeled, opened, synchronize, reopened]
-# Only trigger the benchmark job when you add `run benchmark` label to the PR
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   Benchmark:
     runs-on: ubuntu-latest

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,8 +12,12 @@ include("hessian.jl")
 SUITE = BenchmarkGroup()
 for G in SET_TYPES
     H = Set{Tuple{Int,Int}}
-    SUITE["Jacobian"][nameof(G)] = jacbench(TracerSparsityDetector(G))
-    SUITE["Hessian"][(nameof(G), nameof(H))] = hessbench(TracerSparsityDetector(G, H))
+    SUITE["Jacobian"]["Global"][nameof(G)] = jacbench(TracerSparsityDetector(G))
+    SUITE["Jacobian"]["Local"][nameof(G)] = jacbench(TracerLocalSparsityDetector(G))
+    SUITE["Hessian"]["Global"][(nameof(G), nameof(H))] = hessbench(
+        TracerSparsityDetector(G, H)
+    )
+    SUITE["Hessian"]["Local"][(nameof(G), nameof(H))] = hessbench(
+        TracerLocalSparsityDetector(G, H)
+    )
 end
-
-run(SUITE; verbose=true)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,4 +1,5 @@
 using BenchmarkTools
+using SparseConnectivityTracer
 using SparseConnectivityTracer: DuplicateVector, SortedVector, RecursiveSet
 
 SET_TYPES = (
@@ -9,7 +10,10 @@ include("jacobian.jl")
 include("hessian.jl")
 
 SUITE = BenchmarkGroup()
-for S in SET_TYPES
-    SUITE["Jacobian"][nameof(S)] = jacbench(S)
-    SUITE["Hessian"][nameof(S)] = hessbench(S)
+for G in SET_TYPES
+    H = Set{Tuple{Int,Int}}
+    SUITE["Jacobian"][nameof(G)] = jacbench(TracerSparsityDetector(G))
+    SUITE["Hessian"][(nameof(G), nameof(H))] = hessbench(TracerSparsityDetector(G, H))
 end
+
+run(SUITE; verbose=true)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,74 +1,15 @@
 using BenchmarkTools
+using SparseConnectivityTracer: DuplicateVector, SortedVector, RecursiveSet
 
-using ADTypes: AbstractSparsityDetector, jacobian_sparsity
-using SparseConnectivityTracer
-using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
+SET_TYPES = (
+    BitSet, Set{UInt64}, DuplicateVector{UInt64}, RecursiveSet{UInt64}, SortedVector{UInt64}
+)
 
-using SparseArrays: sprand
-using SimpleDiffEq: ODEProblem, solve, SimpleEuler
-using Flux: Conv
+include("jacobian.jl")
+include("hessian.jl")
 
-const SET_TYPES = (BitSet, Set{UInt64}, DuplicateVector{UInt64}, SortedVector{UInt64})
-
-## ODEs
-include("../test/brusselator_definition.jl")
-
-## Iterated multiplication by random sparse matrices
-function iterated_sparse_matmul(x; sparsity=0.1, iterations=5)
-    n = length(x)
-    y = copy(x)
-    for _ in 1:iterations
-        A = sprand(n, n, sparsity)
-        y = A * y
-    end
-    return y
-end
-
-## Deep Learning
-const LAYER = Conv((5, 5), 3 => 2)
-
-## Define Benchmark suite
 SUITE = BenchmarkGroup()
-
 for S in SET_TYPES
-    setname = string(S)
-    method = TracerSparsityDetector(S)
-
-    J_global = SUITE["Jacobian"]["Global"]
-
-    ## Sparse matrix multiplication
-    for sparsity in (0.01, 0.05, 0.1, 0.25)
-        x = rand(50)
-        f(x) = iterated_sparse_matmul(x; sparsity=sparsity, iterations=5)
-        J_global["sparse_matmul"]["sparsity=$sparsity"][setname] = @benchmarkable jacobian_sparsity(
-            $f, $x, $method
-        )
-    end
-
-    ## ODEs
-    for N in (6, 24, 100)
-        f! = Brusselator!(N)
-        x = rand(N, N, 2)
-        y = similar(x)
-        J_global["brusselator"]["N=$N"][setname] = @benchmarkable jacobian_sparsity(
-            $f!, $y, $x, $method
-        )
-
-        solver = SimpleEuler()
-        prob = ODEProblem(brusselator_2d_loop!, x, (0.0, 1.0), f!.params)
-        function brusselator_ode_solve(x)
-            return solve(ODEProblem(brusselator_2d_loop!, x, (0.0, 1.0), f!.params), solver; dt=0.5).u[end]
-        end
-        J_global["brusselator_ode_solve"]["N=$N"][setname] = @benchmarkable jacobian_sparsity(
-            $brusselator_ode_solve, $x, $method
-        )
-    end
-
-    ## Deep Learning
-    for N in (28, 128)
-        J_global["conv"]["size=$(N)x$(N)x3"][setname] = @benchmarkable jacobian_sparsity(
-            $LAYER, $(rand(N, N, 3, 1)), $method
-        )
-    end
-    # TODO: benchmark local sparsity tracers on LeNet-5 CNN
+    SUITE["Jacobian"][nameof(S)] = jacbench(S)
+    SUITE["Hessian"][nameof(S)] = hessbench(S)
 end

--- a/benchmark/hessian.jl
+++ b/benchmark/hessian.jl
@@ -5,7 +5,90 @@ using SparseConnectivityTracer
 
 using SparseArrays: sprand
 
-function hessbench(::Type{S}) where {S}
+#=
+Test cases taken from the article:
+> "On efficient Hessian computation using the edge pushing algorithm in Julia"
+> https://www.tandfonline.com/doi/full/10.1080/10556788.2018.1480625
+=#
+
+function hessbench(method)
     suite = BenchmarkGroup()
+    suite["ArrowHead"] = hessbench_arrowhead(method)
+    suite["RandomSparsity"] = hessbench_randomsparsity(method)
     return suite
 end
+
+## 4.1 Arrow-head structure
+
+struct ArrowHead
+    K::Int
+end
+
+function (ah::ArrowHead)(x::AbstractVector)
+    K = ah.K
+    N = length(x)
+    return sum(1:N) do i
+        s1 = sum(x[i + j] for j in 1:K if (i + j) in eachindex(x); init=zero(eltype(x)))
+        s2 = sum((x[i] + x[j])^2 for j in 1:K)
+        cos(s1) + s2
+    end
+end
+
+function hessbench_arrowhead(method)
+    suite = BenchmarkGroup()
+    for (N, K) in [
+        # Table 1
+        (200, 16),
+        (400, 16),
+        (800, 16),
+        # Table 2
+        (3200, 2),
+        (3200, 4),
+        (3200, 8),
+    ]
+        x = rand(N)
+        f = ArrowHead(K)
+        suite["(N=$N, K=$K)"] = @benchmarkable hessian_sparsity($f, $x, $method)
+    end
+    return suite
+end
+
+# 4.2 Random sparsity structure
+
+struct RandomSparsity
+    rand_sets::Vector{Vector{Int}}
+end
+
+function RandomSparsity(N::Integer, K::Integer)
+    rand_sets = [rand(1:N, K) for i in 1:N]
+    return RandomSparsity(rand_sets)
+end
+
+function (rs::RandomSparsity)(x::AbstractVector)
+    return sum(eachindex(x, rs.rand_sets)) do i
+        (x[i] - 1)^2 + prod(x[rs.rand_sets[i]])
+    end
+end
+
+function hessbench_randomsparsity(method)
+    suite = BenchmarkGroup()
+    for (N, K) in [
+        # Table 3
+        (400, 2),
+        (400, 4),
+        (400, 8),
+        # Table 4
+        (100, 32),
+        (200, 32),
+        (400, 32),
+    ]
+        x = rand(N)
+        f = RandomSparsity(N, K)
+        suite["(N=$N, K=$K)"] = @benchmarkable hessian_sparsity($f, $x, $method)
+    end
+    return suite
+end
+
+# 4.3 Logistic regression
+
+# TODO: Add this test case

--- a/benchmark/hessian.jl
+++ b/benchmark/hessian.jl
@@ -1,0 +1,11 @@
+using BenchmarkTools
+
+using ADTypes: hessian_sparsity
+using SparseConnectivityTracer
+
+using SparseArrays: sprand
+
+function hessbench(::Type{S}) where {S}
+    suite = BenchmarkGroup()
+    return suite
+end

--- a/benchmark/jacobian.jl
+++ b/benchmark/jacobian.jl
@@ -1,0 +1,88 @@
+using BenchmarkTools
+
+using ADTypes: AbstractSparsityDetector, jacobian_sparsity
+using SparseConnectivityTracer
+
+using SparseArrays: sprand
+using SimpleDiffEq: ODEProblem, solve, SimpleEuler
+using Flux: Conv
+
+function jacbench(::Type{S}) where {S}
+    suite = BenchmarkGroup()
+    suite["SparseMul"] = jacbench_sparsemul(S)
+    suite["Brusselator"] = jacbench_brusselator(S)
+    suite["Conv"] = jacbench_conv(S)
+    return suite
+end
+
+## Iterated sparse mul
+
+struct IteratedSparseMul{M<:AbstractMatrix}
+    As::Vector{M}
+end
+
+function IteratedSparseMul(; n::Integer, p::Real=0.1, depth::Integer=5)
+    As = [sprand(n, n, p) for _ in 1:depth]
+    return IteratedSparseMul(As)
+end
+
+function (ism::IteratedSparseMul)(x::AbstractVector)
+    @assert length(x) == size(As[1], 1)
+    y = copy(x)
+    for l in eachindex(ism.As)
+        y = ism.As[l] * y
+    end
+    return y
+end
+
+function jacbench_sparsemul(::Type{S}) where {S}
+    method = TracerSparsityDetector(S)
+    suite = BenchmarkGroup()
+    for n in [50], p in [0.01, 0.05, 0.1, 0.25], depth in [5]
+        x = rand(n)
+        f = IteratedSparseMul(; n, p, depth)
+        suite["(n=$n, p=$p, depth=$depth)"] = @benchmarkable jacobian_sparsity(
+            $f, $x, $method
+        )
+    end
+    return suite
+end
+
+## Brusselator
+
+include("../test/brusselator_definition.jl")
+
+function jacbench_brusselator(::Type{S}) where {S}
+    method = TracerSparsityDetector(S)
+    suite = BenchmarkGroup()
+    for N in (6, 24, 100)
+        f! = Brusselator!(N)
+        x = rand(N, N, 2)
+        y = similar(x)
+        suite["operator"]["N=$N"] = @benchmarkable jacobian_sparsity($f!, $y, $x, $method)
+        solver = SimpleEuler()
+        prob = ODEProblem(brusselator_2d_loop!, x, (0.0, 1.0), f!.params)
+        function brusselator_ode_solve(x)
+            return solve(ODEProblem(brusselator_2d_loop!, x, (0.0, 1.0), f!.params), solver; dt=0.5).u[end]
+        end
+        suite["ODE"]["N=$N"] = @benchmarkable jacobian_sparsity(
+            $brusselator_ode_solve, $x, $method
+        )
+    end
+    return suite
+end
+
+## Convolution
+
+function jacbench_conv(::Type{S}) where {S}
+    # TODO: benchmark local sparsity tracers on LeNet-5 CNN
+    method = TracerSparsityDetector(S)
+    layer = Conv((5, 5), 3 => 2)
+    suite = BenchmarkGroup()
+    for N in (28, 128)
+        suite["size=$(N)x$(N)x3"] = @benchmarkable jacobian_sparsity(
+            $layer, $(rand(N, N, 3, 1)), $method
+        )
+    end
+    return suite
+end

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -215,6 +215,7 @@ Dual(primal::P, tracer::T) where {P,T} = Dual{P,T}(primal, tracer)
 # TODO: support ConnectivityTracer
 
 primal(d::Dual) = d.primal
+primal(p::Real) = p  # TODO: should this be needed?
 tracer(d::Dual) = d.tracer
 
 inputs(d::Dual{P,T}) where {P,T<:ConnectivityTracer} = inputs(d.tracer)

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -215,7 +215,6 @@ Dual(primal::P, tracer::T) where {P,T} = Dual{P,T}(primal, tracer)
 # TODO: support ConnectivityTracer
 
 primal(d::Dual) = d.primal
-primal(p::Real) = p  # TODO: should this be needed?
 tracer(d::Dual) = d.tracer
 
 inputs(d::Dual{P,T}) where {P,T<:ConnectivityTracer} = inputs(d.tracer)


### PR DESCRIPTION
- Restructure Jacobian benchmarks to make them more modular
- Add Hessian benchmarks based on the JuMP hessian article (https://www.tandfonline.com/doi/full/10.1080/10556788.2018.1480625)

> This PR renames benchmark groups and changes the nesting, so it cannot be compared with the `main` branch. But that's ok cause I didn't change the `src` folder, so performance stays the same