### PR TITLE
Fix 3-argument similar and add tests on type conversions

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -13,6 +13,7 @@ for TT in (GradientTracer, ConnectivityTracer, HessianTracer)
     Base.convert(::Type{<:Real}, t::T) where {T<:TT} = t
 
     ## Constants
+    # These are methods defined on types. Methods on variables are in operators.jl 
     Base.zero(::Type{T})        where {T<:TT} = myempty(T)
     Base.one(::Type{T})         where {T<:TT} = myempty(T)
     Base.oneunit(::Type{T})     where {T<:TT} = myempty(T)
@@ -63,13 +64,13 @@ function Base.convert(::Type{Dual{P1,T}}, d::Dual{P2,T}) where {P1,P2,T}
 end
 
 ## Constants
+# These are methods defined on types. Methods on variables are in operators.jl 
 Base.zero(::Type{D})        where {P,T,D<:Dual{P,T}} = D(zero(P),        myempty(T))
 Base.one(::Type{D})         where {P,T,D<:Dual{P,T}} = D(one(P),         myempty(T))
 Base.oneunit(::Type{D})     where {P,T,D<:Dual{P,T}} = D(oneunit(P),     myempty(T))
 Base.typemin(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemin(P),     myempty(T))
 Base.typemax(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemax(P),     myempty(T))
 Base.eps(::Type{D})         where {P,T,D<:Dual{P,T}} = D(eps(P),         myempty(T))
-Base.float(::Type{D})       where {P,T,D<:Dual{P,T}} = D(float(P),       myempty(T))
 Base.floatmin(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmin(P),    myempty(T))
 Base.floatmax(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmax(P),    myempty(T))
 Base.maxintfloat(::Type{D}) where {P,T,D<:Dual{P,T}} = D(maxintfloat(P), myempty(T))

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -8,21 +8,21 @@ for TT in (GradientTracer, ConnectivityTracer, HessianTracer)
     Base.big(::Type{T})   where {T<:TT} = T
     Base.widen(::Type{T}) where {T<:TT} = T
 
-    Base.convert(::Type{T}, x::Real)   where {T<:TT} = empty(T)
+    Base.convert(::Type{T}, x::Real)   where {T<:TT} = myempty(T)
     Base.convert(::Type{T}, t::T)        where {T<:TT} = t
     Base.convert(::Type{<:Real}, t::T) where {T<:TT} = t
 
     ## Constants
-    Base.zero(::Type{T})        where {T<:TT} = empty(T)
-    Base.one(::Type{T})         where {T<:TT} = empty(T)
-    Base.oneunit(::Type{T})     where {T<:TT} = empty(T)
-    Base.typemin(::Type{T})     where {T<:TT} = empty(T)
-    Base.typemax(::Type{T})     where {T<:TT} = empty(T)
-    Base.eps(::Type{T})         where {T<:TT} = empty(T)
-    Base.float(::Type{T})       where {T<:TT} = empty(T)
-    Base.floatmin(::Type{T})    where {T<:TT} = empty(T)
-    Base.floatmax(::Type{T})    where {T<:TT} = empty(T)
-    Base.maxintfloat(::Type{T}) where {T<:TT} = empty(T)
+    Base.zero(::Type{T})        where {T<:TT} = myempty(T)
+    Base.one(::Type{T})         where {T<:TT} = myempty(T)
+    Base.oneunit(::Type{T})     where {T<:TT} = myempty(T)
+    Base.typemin(::Type{T})     where {T<:TT} = myempty(T)
+    Base.typemax(::Type{T})     where {T<:TT} = myempty(T)
+    Base.eps(::Type{T})         where {T<:TT} = myempty(T)
+    Base.float(::Type{T})       where {T<:TT} = myempty(T)
+    Base.floatmin(::Type{T})    where {T<:TT} = myempty(T)
+    Base.floatmax(::Type{T})    where {T<:TT} = myempty(T)
+    Base.maxintfloat(::Type{T}) where {T<:TT} = myempty(T)
     
     ## Array constructors
     Base.similar(a::Array{T,1})                     where {T<:TT}   = zeros(T, size(a, 1))
@@ -54,7 +54,7 @@ end
 Base.big(::Type{D})   where {P,T,D<:Dual{P,T}} = Dual{big(P),T}
 Base.widen(::Type{D}) where {P,T,D<:Dual{P,T}} = Dual{widen(P),T}
 
-Base.convert(::Type{D}, x::Real) where {P,T,D<:Dual{P,T}}           = Dual(x, empty(T))
+Base.convert(::Type{D}, x::Real) where {P,T,D<:Dual{P,T}}           = Dual(x, myempty(T))
 Base.convert(::Type{D}, d::D)      where {P,T,D<:Dual{P,T}}           = d
 Base.convert(::Type{N}, d::D)      where {N<:Real,P,T,D<:Dual{P,T}} = Dual(convert(T, primal(d)), tracer(d))
 
@@ -63,45 +63,49 @@ function Base.convert(::Type{Dual{P1,T}}, d::Dual{P2,T}) where {P1,P2,T}
 end
 
 ## Constants
-Base.zero(::Type{D})        where {P,T,D<:Dual{P,T}} = D(zero(P),        empty(T))
-Base.one(::Type{D})         where {P,T,D<:Dual{P,T}} = D(one(P),         empty(T))
-Base.oneunit(::Type{D})     where {P,T,D<:Dual{P,T}} = D(oneunit(P),     empty(T))
-Base.typemin(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemin(P),     empty(T))
-Base.typemax(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemax(P),     empty(T))
-Base.eps(::Type{D})         where {P,T,D<:Dual{P,T}} = D(eps(P),         empty(T))
-Base.float(::Type{D})       where {P,T,D<:Dual{P,T}} = D(float(P),       empty(T))
-Base.floatmin(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmin(P),    empty(T))
-Base.floatmax(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmax(P),    empty(T))
-Base.maxintfloat(::Type{D}) where {P,T,D<:Dual{P,T}} = D(maxintfloat(P), empty(T))
+Base.zero(::Type{D})        where {P,T,D<:Dual{P,T}} = D(zero(P),        myempty(T))
+Base.one(::Type{D})         where {P,T,D<:Dual{P,T}} = D(one(P),         myempty(T))
+Base.oneunit(::Type{D})     where {P,T,D<:Dual{P,T}} = D(oneunit(P),     myempty(T))
+Base.typemin(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemin(P),     myempty(T))
+Base.typemax(::Type{D})     where {P,T,D<:Dual{P,T}} = D(typemax(P),     myempty(T))
+Base.eps(::Type{D})         where {P,T,D<:Dual{P,T}} = D(eps(P),         myempty(T))
+Base.float(::Type{D})       where {P,T,D<:Dual{P,T}} = D(float(P),       myempty(T))
+Base.floatmin(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmin(P),    myempty(T))
+Base.floatmax(::Type{D})    where {P,T,D<:Dual{P,T}} = D(floatmax(P),    myempty(T))
+Base.maxintfloat(::Type{D}) where {P,T,D<:Dual{P,T}} = D(maxintfloat(P), myempty(T))
 
 ## Array constructors
 function Base.similar(a::Array{D,1}) where {P,T,D<:Dual{P,T}}
     p_out = similar(primal.(a))
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array{D,2}) where {P,T,D<:Dual{P,T}}
     p_out = similar(primal.(a))
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array{A,1}, ::Type{D}) where {P,T,D<:Dual{P,T},A}
     p_out = similar(a, P)
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array{A,2}, ::Type{D}) where {P,T,D<:Dual{P,T},A}
     p_out = similar(a, P)
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array{D}, m::Int) where {P,T,D<:Dual{P,T}}
     p_out = similar(primal.(a), m)
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array{D}, dims::Dims{N}) where {P,T,D<:Dual{P,T}, N}
     p_out = similar(primal.(a), dims)
-    return Dual.(p_out, empty(T))
+    return Dual.(p_out, myempty(T))
+end
+function Base.similar(a::Array{D2}, ::Type{Dual{P,T}}, dims::Dims{N}) where {P,T,N,D2<:Dual}
+    p_out = similar(primal.(a), P, dims)
+    return Dual.(p_out, myempty(T))
 end
 function Base.similar(a::Array, ::Type{Dual{P,T}}, dims::Dims{N}) where {P,T,N}
-    p_out = similar(primal.(a), P, dims)
-    return Dual.(p_out, empty(T))
+    p_out = similar(a, P, dims)
+    return Dual.(p_out, myempty(T))
 end
 
 #! format: on

--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -4,7 +4,7 @@ function connectivity_tracer_1_to_1(
     t::T, is_influence_zero::Bool
 ) where {T<:ConnectivityTracer}
     if is_influence_zero
-        return empty(T)
+        return myempty(T)
     else
         return t
     end
@@ -34,7 +34,7 @@ function connectivity_tracer_2_to_1(
 ) where {T<:ConnectivityTracer}
     if is_influence_arg1_zero
         if is_influence_arg2_zero
-            return empty(T)
+            return myempty(T)
         else
             return ty
         end
@@ -158,4 +158,4 @@ end
 Base.round(t::ConnectivityTracer, ::RoundingMode; kwargs...) = t
 
 ## Random numbers
-Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:ConnectivityTracer} = empty(T)  # TODO: was missing Base, add tests
+Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:ConnectivityTracer} = myempty(T)  # TODO: was missing Base, add tests

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -2,7 +2,7 @@
 
 function gradient_tracer_1_to_1(t::T, is_firstder_zero::Bool) where {T<:GradientTracer}
     if is_firstder_zero
-        return empty(T)
+        return myempty(T)
     else
         return t
     end
@@ -32,7 +32,7 @@ function gradient_tracer_2_to_1(
 ) where {T<:GradientTracer}
     if is_firstder_arg1_zero
         if is_firstder_arg2_zero
-            return empty(T)
+            return myempty(T)
         else
             return ty
         end
@@ -149,12 +149,12 @@ for S in (Integer, Rational, Irrational{:ℯ})
 end
 
 ## Rounding
-Base.round(t::T, ::RoundingMode; kwargs...) where {T<:GradientTracer} = empty(T)
+Base.round(t::T, ::RoundingMode; kwargs...) where {T<:GradientTracer} = myempty(T)
 function Base.round(
     d::D, mode::RoundingMode; kwargs...
 ) where {P,T<:GradientTracer,D<:Dual{P,T}}
-    return Dual(round(primal(d), mode; kwargs...), empty(T))
+    return Dual(round(primal(d), mode; kwargs...), myempty(T))
 end
 
 ## Random numbers 
-Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:GradientTracer} = empty(T)  # TODO: was missing Base, add tests
+Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:GradientTracer} = myempty(T)  # TODO: was missing Base, add tests

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -5,13 +5,13 @@ function hessian_tracer_1_to_1(
 ) where {G,H,T<:HessianTracer{G,H}}
     if is_seconder_zero
         if is_firstder_zero
-            return empty(T)
+            return myempty(T)
         else
             return t
         end
     else
         if is_firstder_zero
-            return T(empty(G), gradient(t) × gradient(t))
+            return T(myempty(G), gradient(t) × gradient(t))
         else
             return T(gradient(t), hessian(t) ∪ (gradient(t) × gradient(t)))
         end
@@ -52,8 +52,8 @@ function hessian_tracer_2_to_1(
     is_seconder_arg2_zero::Bool,
     is_crossder_zero::Bool,
 ) where {G,H,T<:HessianTracer{G,H}}
-    grad = empty(G)
-    hess = empty(H)
+    grad = myempty(G)
+    hess = myempty(H)
     if !is_firstder_arg1_zero
         grad = union(grad, gradient(a)) # TODO: use union!
         union!(hess, hessian(a))
@@ -208,7 +208,7 @@ for S in (Integer, Rational, Irrational{:ℯ})
 end
 
 ## Rounding
-Base.round(t::T, ::RoundingMode; kwargs...) where {T<:HessianTracer} = empty(T)
+Base.round(t::T, ::RoundingMode; kwargs...) where {T<:HessianTracer} = myempty(T)
 
 ## Random numbers
-Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:HessianTracer} = empty(T)  # TODO: was missing Base, add tests
+Base.rand(::AbstractRNG, ::SamplerType{T}) where {T<:HessianTracer} = myempty(T)  # TODO: was missing Base, add tests

--- a/src/pattern.jl
+++ b/src/pattern.jl
@@ -391,11 +391,11 @@ function hessian_pattern_to_mat(
 end
 
 function hessian_pattern_to_mat(xt::AbstractArray{T}, yt::Number) where {T<:HessianTracer}
-    return hessian_pattern_to_mat(xt, empty(T))
+    return hessian_pattern_to_mat(xt, myempty(T))
 end
 
 function hessian_pattern_to_mat(
     xt::AbstractArray{D1}, yt::Number
 ) where {P1,T<:HessianTracer,D1<:Dual{P1,T}}
-    return hessian_pattern_to_mat(tracer.(xt), empty(T))
+    return hessian_pattern_to_mat(tracer.(xt), myempty(T))
 end

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -1,8 +1,8 @@
 abstract type AbstractTracer <: Real end
 
 # Convenience constructor for empty tracers
-empty(tracer::T) where {T<:AbstractTracer} = empty(T)
-empty(T) = T()
+myempty(tracer::T) where {T<:AbstractTracer} = myempty(T)
+myempty(T) = T()
 
 sparse_vector(T, index) = T([index])
 
@@ -50,8 +50,8 @@ function Base.show(io::IO, t::ConnectivityTracer)
     )
 end
 
-function empty(::Type{ConnectivityTracer{C}}) where {C}
-    return ConnectivityTracer{C}(empty(C))
+function myempty(::Type{ConnectivityTracer{C}}) where {C}
+    return ConnectivityTracer{C}(myempty(C))
 end
 
 # We have to be careful when defining constructors:
@@ -59,7 +59,7 @@ end
 # by calling `T(x)` (instead of `convert(T, x)`), where `T` can be `ConnectivityTracer`.
 # When this happens, we create a new empty tracer with no input pattern.
 function ConnectivityTracer{C}(::Real) where {C<:AbstractSet{<:Integer}}
-    return empty(ConnectivityTracer{C})
+    return myempty(ConnectivityTracer{C})
 end
 
 ConnectivityTracer{C}(t::ConnectivityTracer{C}) where {C<:AbstractSet{<:Integer}} = t
@@ -103,12 +103,12 @@ function Base.show(io::IO, t::GradientTracer)
     )
 end
 
-function empty(::Type{GradientTracer{G}}) where {G}
-    return GradientTracer{G}(empty(G))
+function myempty(::Type{GradientTracer{G}}) where {G}
+    return GradientTracer{G}(myempty(G))
 end
 
 function GradientTracer{G}(::Real) where {G<:AbstractSet{<:Integer}}
-    return empty(GradientTracer{G})
+    return myempty(GradientTracer{G})
 end
 
 GradientTracer{G}(t::GradientTracer{G}) where {G<:AbstractSet{<:Integer}} = t
@@ -167,14 +167,14 @@ function Base.show(io::IO, t::HessianTracer)
     return nothing
 end
 
-function empty(::Type{HessianTracer{G,H}}) where {G,H}
-    return HessianTracer{G,H}(empty(G), empty(H))
+function myempty(::Type{HessianTracer{G,H}}) where {G,H}
+    return HessianTracer{G,H}(myempty(G), myempty(H))
 end
 
 function HessianTracer{G,H}(
     ::Real
 ) where {G<:AbstractSet{<:Integer},H<:AbstractSet{<:Tuple{Integer,Integer}}}
-    return empty(HessianTracer{G,H})
+    return myempty(HessianTracer{G,H})
 end
 
 function HessianTracer{G,H}(
@@ -223,7 +223,7 @@ gradient(d::Dual{P,T}) where {P,T<:HessianTracer} = gradient(d.tracer)
 hessian(d::Dual{P,T}) where {P,T<:HessianTracer} = hessian(d.tracer)
 
 function Dual{P,T}(x::Real) where {P<:Real,T<:AbstractTracer}
-    return Dual(convert(P, x), empty(T))
+    return Dual(convert(P, x), myempty(T))
 end
 
 #===========#
@@ -246,5 +246,5 @@ function create_tracer(::Type{ConnectivityTracer{C}}, ::Real, index::Integer) wh
     return ConnectivityTracer{C}(sparse_vector(C, index))
 end
 function create_tracer(::Type{HessianTracer{G,H}}, ::Real, index::Integer) where {G,H}
-    return HessianTracer{G,H}(sparse_vector(G, index), empty(H))
+    return HessianTracer{G,H}(sparse_vector(G, index), myempty(H))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,9 @@ DocMeta.setdocmeta!(
     end
 
     @testset verbose = true "Simple examples" begin
+        @testset "Tracer Construction" begin
+            include("test_connectivity.jl")
+        end
         @testset "ConnectivityTracer" begin
             include("test_connectivity.jl")
         end

--- a/test/test_connectivity.jl
+++ b/test/test_connectivity.jl
@@ -89,10 +89,5 @@ end
             x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 3 2 4], S
         ) == [0 0 1 1]
         @test local_connectivity_pattern(x -> 0, 1, S) ≈ [0;;]
-
-        # Putting Duals into Duals is prohibited
-        C = empty(ConnectivityTracer{S})
-        D1 = Dual(1.0, C)
-        @test_throws ErrorException D2 = Dual(D1, C)
     end
 end

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -1,0 +1,101 @@
+# Test construction and conversions of internal tracer types
+using SparseConnectivityTracer: ConnectivityTracer, GradientTracer, HessianTracer, Dual
+using SparseConnectivityTracer: inputs, gradient, hessian, primal, tracer, myempty
+using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
+using Test
+
+const FIRST_ORDER_SET_TYPES = (
+    BitSet, Set{UInt64}, DuplicateVector{UInt64}, RecursiveSet{UInt64}, SortedVector{UInt64}
+)
+
+is_tracer_empty(t::ConnectivityTracer) = isempty(inputs(t))
+is_tracer_empty(t::GradientTracer)     = isempty(gradient(t))
+is_tracer_empty(t::HessianTracer)      = isempty(gradient(t)) && isempty(hessian(t))
+is_tracer_empty(d::Dual)               = is_tracer_empty(tracer(d))
+
+@testset "Set type $S1" for S1 in FIRST_ORDER_SET_TYPES
+    I = eltype(S1)
+    S2 = Set{Tuple{I,I}}
+
+    C = ConnectivityTracer{S1}
+    G = GradientTracer{S1}
+    H = HessianTracer{S1,S2}
+
+    TD = Float32
+    DC = Dual{TD,C}
+    DG = Dual{TD,G}
+    DH = Dual{TD,H}
+
+    # Putting Duals into Duals is prohibited
+    @testset "Nested Duals $T" for T in (C, G, H)
+        t = myempty(T)
+        D1 = Dual(1.0, t)
+        @test_throws ErrorException D2 = Dual(D1, t)
+    end
+
+    # Test `similar`
+    TA = Float16   # using something different than TD
+    @test TA != TD # this is important for following tests
+
+    A = rand(TA, 2, 3)
+    @testset "Similar $T" for T in (C, G, H, DC, DG, DH)
+        # From matrix of Reals
+        B = similar(A, T)
+        @test eltype(B) == T
+        @test size(B) == (2, 3)
+        @test all(is_tracer_empty, B)
+        if T <: Dual
+            @test all(d -> eltype(primal(d)) == TD, B)
+        end
+
+        # From matrix of tracers
+        BD = similar(B, T)
+        @test eltype(BD) == T
+        @test size(BD) == (2, 3)
+        @test all(is_tracer_empty, BD)
+        if T <: Dual
+            @test all(d -> eltype(primal(d)) == TD, BD)
+        end
+
+        # From matrix of tracers, custom size
+        BD2 = similar(B, 4, 5)
+        @test eltype(BD2) == T
+        @test size(BD2) == (4, 5)
+        @test all(is_tracer_empty, BD2)
+        if T <: Dual
+            @test all(d -> eltype(primal(d)) == TD, BD2)
+        end
+
+        # 3-arg from matrix of Reals
+        B = similar(A, T, 4, 5)
+        @test eltype(B) == T
+        @test size(B) == (4, 5)
+        @test all(is_tracer_empty, B)
+        if T <: Dual
+            @test all(d -> eltype(primal(d)) == TD, B)
+        end
+
+        # 3-arg from matrix of tracers
+        BD = similar(B, T, 5, 6)
+        @test eltype(BD) == T
+        @test size(BD) == (5, 6)
+        @test all(is_tracer_empty, BD)
+        if T <: Dual
+            @test all(d -> eltype(primal(d)) == TD, BD)
+        end
+    end
+
+    # Constant constructors by type
+    @testset "$f" for f in (
+        zero, one, oneunit, typemin, typemax, eps, floatmin, floatmax, maxintfloat
+    )
+        @testset "$T" for T in (C, G, H, DC, DG, DH)
+            t = f(T)
+            @test isa(t, T)
+            @test is_tracer_empty(t)
+            if T <: Dual
+                @test primal(t) == f(TD)
+            end
+        end
+    end
+end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -161,7 +161,7 @@ end
         @test jacobian_sparsity(NNlib.softshrink, 1, method) ≈ [1;;]
 
         # Putting Duals into Duals is prohibited
-        G = empty(GradientTracer{S})
+        G = myempty(GradientTracer{S})
         D1 = Dual(1.0, G)
         @test_throws ErrorException D2 = Dual(D1, G)
     end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -1,6 +1,6 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer:
-    GradientTracer, Dual, MissingPrimalError, tracer, trace_input, empty
+    GradientTracer, Dual, MissingPrimalError, tracer, trace_input
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using ADTypes: jacobian_sparsity
 using LinearAlgebra: det, dot, logdet
@@ -159,10 +159,5 @@ end
         @test jacobian_sparsity(NNlib.softshrink, -1, method) ≈ [1;;]
         @test jacobian_sparsity(NNlib.softshrink, 0, method) ≈ [0;;]
         @test jacobian_sparsity(NNlib.softshrink, 1, method) ≈ [1;;]
-
-        # Putting Duals into Duals is prohibited
-        G = myempty(GradientTracer{S})
-        D1 = Dual(1.0, G)
-        @test_throws ErrorException D2 = Dual(D1, G)
     end
 end

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -211,7 +211,7 @@ end
         @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
 
         # Putting Duals into Duals is prohibited
-        H = empty(HessianTracer{S,Set{Tuple{Int,Int}}})
+        H = myempty(HessianTracer{S,Set{Tuple{Int,Int}}})
         D1 = Dual(1.0, H)
         @test_throws ErrorException D2 = Dual(D1, H)
     end

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -1,6 +1,5 @@
 using SparseConnectivityTracer
-using SparseConnectivityTracer:
-    HessianTracer, MissingPrimalError, tracer, trace_input, empty
+using SparseConnectivityTracer: HessianTracer, MissingPrimalError, tracer, trace_input
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using ADTypes: hessian_sparsity
 using SpecialFunctions: erf, beta
@@ -209,10 +208,5 @@ end
         @test hessian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
-
-        # Putting Duals into Duals is prohibited
-        H = myempty(HessianTracer{S,Set{Tuple{Int,Int}}})
-        D1 = Dual(1.0, H)
-        @test_throws ErrorException D2 = Dual(D1, H)
     end
 end


### PR DESCRIPTION
Had to remove the `Dual` overload of `Base.float` on types:
`float(T)` returns a type, not a number usable for the primal.