### PR TITLE
Fix tracer overloads on exponent function

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -163,7 +163,7 @@ function connectivity_pattern_to_mat(
     J = Int[] # column indices
     V = Bool[]   # values
     for (i, y) in enumerate(yt)
-        if y isa T
+        if y isa T && !isemptytracer(y)
             for j in inputs(y)
                 push!(I, i)
                 push!(J, j)
@@ -280,7 +280,7 @@ function jacobian_pattern_to_mat(
     J = Int[] # column indices
     V = Bool[]   # values
     for (i, y) in enumerate(yt)
-        if y isa T
+        if y isa T && !isemptytracer(y)
             for j in gradient(y)
                 push!(I, i)
                 push!(J, j)
@@ -388,10 +388,12 @@ function hessian_pattern_to_mat(xt::AbstractArray{T}, yt::T) where {T<:HessianTr
     J = Int[] # column indices
     V = Bool[]   # values
 
-    for (i, j) in hessian(yt)
-        push!(I, i)
-        push!(J, j)
-        push!(V, true)
+    if !isemptytracer(yt)
+        for (i, j) in hessian(yt)
+            push!(I, i)
+            push!(J, j)
+            push!(V, true)
+        end
     end
     h = sparse(I, J, V, n, n)
     return h

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -196,25 +196,17 @@ end
 
 ## Exponent (requires extra types)
 for S in (Integer, Rational, Irrational{:ℯ})
-    function Base.:^(t::T, ::S) where {T<:GradientTracer}
-        g_out = gradient_tracer_1_to_1_inner(gradient(t), false)
-        return T(g_out)
-    end
-    function Base.:^(::S, t::T) where {T<:GradientTracer}
-        g_out = gradient_tracer_1_to_1_inner(gradient(t), false)
-        return T(g_out)
-    end
+    Base.:^(t::T, ::S) where {T<:GradientTracer} = t
+    Base.:^(::S, t::T) where {T<:GradientTracer} = t
     function Base.:^(d::D, y::S) where {P,T<:GradientTracer,D<:Dual{P,T}}
         x = primal(d)
         t = tracer(d)
-        g_out = gradient_tracer_1_to_1_inner(gradient(t), false)
-        return Dual(x^y, T(g_out))
+        return Dual(x^y, t)
     end
     function Base.:^(x::S, d::D) where {P,T<:GradientTracer,D<:Dual{P,T}}
         y = primal(d)
         t = tracer(d)
-        g_out = gradient_tracer_1_to_1_inner(gradient(t), false)
-        return Dual(x^y, T(g_out))
+        return Dual(x^y, t)
     end
 end
 

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -270,12 +270,8 @@ end
 
 ## Exponent (requires extra types)
 for S in (Integer, Rational, Irrational{:ℯ})
-    function Base.:^(t::T, ::S) where {T<:HessianTracer}
-        return hessian_tracer_1_to_1(t, false, false)
-    end
-    function Base.:^(::S, t::T) where {T<:HessianTracer}
-        return hessian_tracer_1_to_1(t, false, false)
-    end
+    Base.:^(t::T, ::S) where {T<:HessianTracer} = hessian_tracer_1_to_1(t, false, false)
+    Base.:^(::S, t::T) where {T<:HessianTracer} = hessian_tracer_1_to_1(t, false, false)
 
     function Base.:^(d::D, y::S) where {P,T<:HessianTracer,D<:Dual{P,T}}
         x = primal(d)

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -271,25 +271,21 @@ end
 ## Exponent (requires extra types)
 for S in (Integer, Rational, Irrational{:ℯ})
     function Base.:^(t::T, ::S) where {T<:HessianTracer}
-        g_out, h_out = hessian_tracer_1_to_1_inner(gradient(t), hessian(t), false, false)
-        return T(g_out, h_out)
+        return hessian_tracer_1_to_1(t, false, false)
     end
     function Base.:^(::S, t::T) where {T<:HessianTracer}
-        g_out, h_out = hessian_tracer_1_to_1_inner(gradient(t), hessian(t), false, false)
-        return T(g_out, h_out)
+        return hessian_tracer_1_to_1(t, false, false)
     end
 
     function Base.:^(d::D, y::S) where {P,T<:HessianTracer,D<:Dual{P,T}}
         x = primal(d)
-        t = tracer(d)
-        g_out, h_out = hessian_tracer_1_to_1_inner(gradient(t), hessian(t), false, false)
-        return Dual(x^y, T(g_out, h_out))
+        t = hessian_tracer_1_to_1(tracer(d), false, false)
+        return Dual(x^y, t)
     end
     function Base.:^(x::S, d::D) where {P,T<:HessianTracer,D<:Dual{P,T}}
         y = primal(d)
-        t = tracer(d)
-        g_out, h_out = hessian_tracer_1_to_1_inner(gradient(t), hessian(t), false, false)
-        return Dual(x^y, T(g_out, h_out))
+        t = hessian_tracer_1_to_1(tracer(d), false, false)
+        return Dual(x^y, t)
     end
 end
 

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -1,5 +1,9 @@
 abstract type AbstractTracer <: Real end
 
+# Trait to call empty constructor
+struct EmptyInitializer end
+const emptyinit = EmptyInitializer()
+
 #===================#
 # Set operations    #
 #===================#
@@ -39,8 +43,8 @@ struct ConnectivityTracer{I} <: AbstractTracer
     function ConnectivityTracer{I}(inputs::I, isempty::Bool=false) where {I}
         return new{I}(isempty, inputs)
     end
-    function ConnectivityTracer{I}(::UndefInitializer) where {I}
-        return new{I}(true)
+    function ConnectivityTracer{I}(::EmptyInitializer) where {I}
+        return new{I}(true) # partial initialization with empty `inputs` field
     end
 end
 
@@ -92,8 +96,8 @@ struct GradientTracer{G} <: AbstractTracer
     function GradientTracer{G}(gradient::G, isempty::Bool=false) where {G}
         return new{G}(isempty, gradient)
     end
-    function GradientTracer{G}(::UndefInitializer) where {G}
-        return new{G}(true)
+    function GradientTracer{G}(::EmptyInitializer) where {G}
+        return new{G}(true) # partial initialization with empty `gradient` field
     end
 end
 
@@ -142,8 +146,8 @@ struct HessianTracer{G,H} <: AbstractTracer
     function HessianTracer{G,H}(gradient::G, hessian::H, isempty::Bool=false) where {G,H}
         return new{G,H}(isempty, gradient, hessian)
     end
-    function HessianTracer{G,H}(::UndefInitializer) where {G,H}
-        return new{G,H}(true)
+    function HessianTracer{G,H}(::EmptyInitializer) where {G,H}
+        return new{G,H}(true) # partial initialization with empty `gradient` and `hessian` fields
     end
 end
 
@@ -215,9 +219,9 @@ end
 # Utilities #
 #===========#
 
-@inline myempty(::Type{ConnectivityTracer{I}}) where {I} = ConnectivityTracer{I}(undef)
-@inline myempty(::Type{GradientTracer{G}}) where {G}     = GradientTracer{G}(undef)
-@inline myempty(::Type{HessianTracer{G,H}}) where {G,H}  = HessianTracer{G,H}(undef)
+@inline myempty(::Type{ConnectivityTracer{I}}) where {I} = ConnectivityTracer{I}(emptyinit)
+@inline myempty(::Type{GradientTracer{G}}) where {G}     = GradientTracer{G}(emptyinit)
+@inline myempty(::Type{HessianTracer{G,H}}) where {G,H}  = HessianTracer{G,H}(emptyinit)
 
 """
     create_tracer(T, index) where {T<:AbstractTracer}

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -94,8 +94,6 @@ GradientTracer(t::GradientTracer) = t
 
 gradient(t::GradientTracer) = t.gradient
 isemptytracer(t::GradientTracer) = t.isempty
-@noinline sorted_gradient(t::GradientTracer{S}) where {S<:AbstractSet} =
-    sort(collect(gradient(t)))
 
 function Base.show(io::IO, t::GradientTracer)
     print(io, typeof(t))

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -67,6 +67,12 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
         @test jacobian_sparsity(x -> round(x, RoundNearestTiesUp), 1, method) ≈ [0;;]
         @test jacobian_sparsity(x -> 0, 1, method) ≈ [0;;]
 
+        # Test special cases on empty tracer
+        @test jacobian_sparsity(x -> zero(x)^(2//3), 1, method) ≈ [0;;]
+        @test jacobian_sparsity(x -> (2//3)^zero(x), 1, method) ≈ [0;;]
+        @test jacobian_sparsity(x -> zero(x)^ℯ, 1, method) ≈ [0;;]
+        @test jacobian_sparsity(x -> ℯ^zero(x), 1, method) ≈ [0;;]
+
         # Linear Algebra
         @test jacobian_sparsity(x -> dot(x[1:2], x[4:5]), rand(5), method) == [1 1 0 1 1]
 

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -262,5 +262,11 @@ end
         @test hessian_sparsity(x -> x^ℯ, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> ℯ^x, 1, method) ≈ [1;;]
         @test hessian_sparsity(x -> 0, 1, method) ≈ [0;;]
+
+        # Test special cases on empty tracer
+        @test hessian_sparsity(x -> zero(x)^(2//3), 1, method) ≈ [0;;]
+        @test hessian_sparsity(x -> (2//3)^zero(x), 1, method) ≈ [0;;]
+        @test hessian_sparsity(x -> zero(x)^ℯ, 1, method) ≈ [0;;]
+        @test hessian_sparsity(x -> ℯ^zero(x), 1, method) ≈ [0;;]
     end
 end


### PR DESCRIPTION
~~This is an attempt at faster empty tracer construction by leaving sparsity-patterns fields undefined using partial initialization.~~
~~This is possible due to the addition of the `isempty` field in #119.~~

This PR cleans up some minor things:
* have specialized `^` methods call "outer" overloads instead of "inner" overloads and add tests for this
* improve printing of tracers
* let the Julia compiler figure out inlining
* refactor `test_similar` to not look at tracer internals