### PR TITLE
Avoid allocating new tracers

### DIFF
--- a/src/overload_connectivity.jl
+++ b/src/overload_connectivity.jl
@@ -3,21 +3,10 @@
 @noinline function connectivity_tracer_1_to_1(
     t::T, is_influence_zero::Bool
 ) where {T<:ConnectivityTracer}
-    if isemptytracer(t) # TODO: add test
+    if is_influence_zero && !isemptytracer(t)
+        return myempty(T)
+    else
         return t
-    else
-        i_out = connectivity_tracer_1_to_1_inner(inputs(t), is_influence_zero)
-        return T(i_out) # return tracer
-    end
-end
-
-function connectivity_tracer_1_to_1_inner(
-    s::S, is_influence_zero::Bool
-) where {S<:AbstractSet{<:Integer}}
-    if is_influence_zero
-        return myempty(S)
-    else
-        return s # return set
     end
 end
 
@@ -152,19 +141,10 @@ end
     if isemptytracer(t) # TODO: add test
         return (t, t)
     else
-        i_out1, i_out2 = connectivity_tracer_1_to_2_inner(
-            inputs(t), is_influence_out1_zero, is_influence_out2_zero
-        )
-        return (T(i_out1), T(i_out2)) # return tracers 
+        t_out1 = connectivity_tracer_1_to_1(t, is_influence_out1_zero)
+        t_out2 = connectivity_tracer_1_to_1(t, is_influence_out2_zero)
+        return (t_out1, t_out2) # return tracers 
     end
-end
-
-function connectivity_tracer_1_to_2_inner(
-    s::S, is_influence_out1_zero::Bool, is_influence_out2_zero::Bool
-) where {S<:AbstractSet{<:Integer}}
-    s_out1 = connectivity_tracer_1_to_1_inner(s, is_influence_out1_zero)
-    s_out2 = connectivity_tracer_1_to_1_inner(s, is_influence_out2_zero)
-    return (s_out1, s_out2) # return sets
 end
 
 function overload_connectivity_1_to_2(M, op)

--- a/src/overload_gradient.jl
+++ b/src/overload_gradient.jl
@@ -3,14 +3,14 @@
 @noinline function gradient_tracer_1_to_1(
     t::T, is_firstder_zero::Bool
 ) where {T<:GradientTracer}
-    if isemptytracer(t) # TODO: add test
-        return t
+    if is_firstder_zero && !isemptytracer(t)
+        return myempty(T)
     else
-        g_out = gradient_tracer_1_to_1_inner(gradient(t), is_firstder_zero)
-        return T(g_out) # return tracer
+        return t
     end
 end
 
+# Called by HessianTracer with AbstractSet
 function gradient_tracer_1_to_1_inner(
     s::S, is_firstder_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}
@@ -148,19 +148,10 @@ end
     if isemptytracer(t) # TODO: add test
         return (t, t)
     else
-        g_out1, g_out2 = gradient_tracer_1_to_2_inner(
-            gradient(t), is_firstder_out1_zero, is_firstder_out2_zero
-        )
-        return (T(g_out1), T(g_out2)) # return tracers
+        t_out1 = gradient_tracer_1_to_1(t, is_firstder_out1_zero)
+        t_out2 = gradient_tracer_1_to_1(t, is_firstder_out2_zero)
+        return (t_out1, t_out2)
     end
-end
-
-function gradient_tracer_1_to_2_inner(
-    s::S, is_firstder_out1_zero::Bool, is_firstder_out2_zero::Bool
-) where {S<:AbstractSet{<:Integer}}
-    s_out1 = gradient_tracer_1_to_1_inner(s, is_firstder_out1_zero)
-    s_out2 = gradient_tracer_1_to_1_inner(s, is_firstder_out2_zero)
-    return (s_out1, s_out2)
 end
 
 function overload_gradient_1_to_2(M, op)

--- a/src/overload_hessian.jl
+++ b/src/overload_hessian.jl
@@ -204,33 +204,10 @@ end
     if isemptytracer(t) # TODO: add test
         return (t, t)
     else
-        (g_out1, h_out1), (g_out2, h_out2) = hessian_tracer_1_to_2_inner(
-            gradient(t),
-            hessian(t),
-            is_firstder_out1_zero,
-            is_seconder_out1_zero,
-            is_firstder_out2_zero,
-            is_seconder_out2_zero,
-        )
-        return (T(g_out1, h_out1), T(g_out2, h_out2)) # return tracers
+        t_out1 = hessian_tracer_1_to_1(t, is_firstder_out1_zero, is_seconder_out1_zero)
+        t_out2 = hessian_tracer_1_to_1(t, is_firstder_out2_zero, is_seconder_out2_zero)
+        return (t_out1, t_out2)
     end
-end
-
-function hessian_tracer_1_to_2_inner(
-    sg::G,
-    sh::H,
-    is_firstder_out1_zero::Bool,
-    is_secondder_out1_zero::Bool,
-    is_firstder_out2_zero::Bool,
-    is_secondder_out2_zero::Bool,
-) where {I<:Integer,G<:AbstractSet{I},H<:AbstractSet{Tuple{I,I}}}
-    sg_out1, sh_out1 = hessian_tracer_1_to_1_inner(
-        sg, sh, is_firstder_out1_zero, is_secondder_out1_zero
-    )
-    sg_out2, sh_out2 = hessian_tracer_1_to_1_inner(
-        sg, sh, is_firstder_out2_zero, is_secondder_out2_zero
-    )
-    return (sg_out1, sh_out1), (sg_out2, sh_out2) # return sets
 end
 
 function overload_hessian_1_to_2(M, op)


### PR DESCRIPTION
Some calls to "inner" overloads can be completely removed, which should avoid the allocation of new sets. 