### PR TITLE
Introduce sparsity patterns

### DIFF
--- a/benchmark/bench_jogger.jl
+++ b/benchmark/bench_jogger.jl
@@ -4,6 +4,7 @@ Pkg.develop(; path=joinpath(@__DIR__, "SparseConnectivityTracerBenchmarks"))
 using BenchmarkTools
 using SparseConnectivityTracer
 using SparseConnectivityTracer: GradientTracer, HessianTracer
+using SparseConnectivityTracer: IndexSetVectorPattern, IndexSetHessianPattern
 using SparseConnectivityTracer: DuplicateVector, SortedVector, RecursiveSet
 
 SET_TYPES = (BitSet, Set{Int}, DuplicateVector{Int}, RecursiveSet{Int}, SortedVector{Int})
@@ -19,8 +20,11 @@ suite["OptimizationProblems"] = optbench([:britgas])
 for S1 in SET_TYPES
     S2 = Set{Tuple{Int,Int}}
 
-    G = GradientTracer{S1}
-    H = HessianTracer{S1,S2}
+    PG = IndexSetVectorPattern{Int,S1}
+    PH = IndexSetHessianPattern{Int,S1,S2}
+
+    G = GradientTracer{PG}
+    H = HessianTracer{PH}
 
     suite["Jacobian"]["Global"][nameof(S1)] = jacbench(TracerSparsityDetector(G, H))
     suite["Jacobian"]["Local"][nameof(S1)] = jacbench(TracerLocalSparsityDetector(G, H))

--- a/benchmark/bench_jogger.jl
+++ b/benchmark/bench_jogger.jl
@@ -4,7 +4,7 @@ Pkg.develop(; path=joinpath(@__DIR__, "SparseConnectivityTracerBenchmarks"))
 using BenchmarkTools
 using SparseConnectivityTracer
 using SparseConnectivityTracer: GradientTracer, HessianTracer
-using SparseConnectivityTracer: IndexSetVectorPattern, IndexSetHessianPattern
+using SparseConnectivityTracer: IndexSetGradientPattern, IndexSetHessianPattern
 using SparseConnectivityTracer: DuplicateVector, SortedVector, RecursiveSet
 
 SET_TYPES = (BitSet, Set{Int}, DuplicateVector{Int}, RecursiveSet{Int}, SortedVector{Int})
@@ -20,7 +20,7 @@ suite["OptimizationProblems"] = optbench([:britgas])
 for S1 in SET_TYPES
     S2 = Set{Tuple{Int,Int}}
 
-    PG = IndexSetVectorPattern{Int,S1}
+    PG = IndexSetGradientPattern{Int,S1}
     PH = IndexSetHessianPattern{Int,S1,S2}
 
     G = GradientTracer{PG}

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -19,6 +19,10 @@ include("settypes/duplicatevector.jl")
 include("settypes/recursiveset.jl")
 include("settypes/sortedvector.jl")
 
+abstract type AbstractPattern end
+abstract type AbstractTracer{P<:AbstractPattern} <: Real end
+
+include("patterns.jl")
 include("tracers.jl")
 include("exceptions.jl")
 include("operators.jl")

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -19,9 +19,6 @@ include("settypes/duplicatevector.jl")
 include("settypes/recursiveset.jl")
 include("settypes/sortedvector.jl")
 
-abstract type AbstractPattern end
-abstract type AbstractTracer{P<:AbstractPattern} <: Real end
-
 include("patterns.jl")
 include("tracers.jl")
 include("exceptions.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,6 +1,8 @@
-const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{BitSet}
-const DEFAULT_GRADIENT_TRACER = GradientTracer{BitSet}
-const DEFAULT_HESSIAN_TRACER = HessianTracer{BitSet,Set{Tuple{Int,Int}}}
+const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{IndexSetVector{Int,BitSet}}
+const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetVector{Int,BitSet}}
+const DEFAULT_HESSIAN_TRACER = HessianTracer{
+    IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}}
+}
 
 #==================#
 # Enumerate inputs #

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,7 +1,7 @@
-const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{IndexSetVector{Int,BitSet}}
-const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetVector{Int,BitSet}}
+const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{IndexSetVectorPattern{Int,BitSet}}
+const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetVectorPattern{Int,BitSet}}
 const DEFAULT_HESSIAN_TRACER = HessianTracer{
-    IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}}
+    IndexSetHessianPattern{Int,BitSet,Set{Tuple{Int,Int}}}
 }
 
 #==================#

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
-const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{IndexSetVectorPattern{Int,BitSet}}
-const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetVectorPattern{Int,BitSet}}
+const DEFAULT_CONNECTIVITY_TRACER = ConnectivityTracer{IndexSetGradientPattern{Int,BitSet}}
+const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetGradientPattern{Int,BitSet}}
 const DEFAULT_HESSIAN_TRACER = HessianTracer{
     IndexSetHessianPattern{Int,BitSet,Set{Tuple{Int,Int}}}
 }

--- a/src/overloads/connectivity_tracer.jl
+++ b/src/overloads/connectivity_tracer.jl
@@ -57,7 +57,7 @@ end
 
 function connectivity_tracer_2_to_1_inner(
     px::P, py::P, is_infl_arg1_zero::Bool, is_infl_arg2_zero::Bool
-) where {P<:IndexSetVector}
+) where {P<:IndexSetVectorPattern}
     if is_infl_arg1_zero && is_infl_arg2_zero
         return myempty(P)
     elseif !is_infl_arg1_zero && is_infl_arg2_zero

--- a/src/overloads/connectivity_tracer.jl
+++ b/src/overloads/connectivity_tracer.jl
@@ -49,23 +49,23 @@ end
         return connectivity_tracer_1_to_1(ty, is_infl_arg2_zero)
     else
         i_out = connectivity_tracer_2_to_1_inner(
-            inputs(tx), inputs(ty), is_infl_arg1_zero, is_infl_arg2_zero
+            pattern(tx), pattern(ty), is_infl_arg1_zero, is_infl_arg2_zero
         )
         return T(i_out) # return tracer 
     end
 end
 
 function connectivity_tracer_2_to_1_inner(
-    sx::S, sy::S, is_infl_arg1_zero::Bool, is_infl_arg2_zero::Bool
-) where {S<:AbstractSet{<:Integer}}
+    px::P, py::P, is_infl_arg1_zero::Bool, is_infl_arg2_zero::Bool
+) where {P<:IndexSetVector}
     if is_infl_arg1_zero && is_infl_arg2_zero
-        return myempty(S)
+        return myempty(P)
     elseif !is_infl_arg1_zero && is_infl_arg2_zero
-        return sx
+        return px
     elseif is_infl_arg1_zero && !is_infl_arg2_zero
-        return sy
+        return py
     else
-        return union(sx, sy) # return set
+        return P(union(set(px), set(py))) # return pattern
     end
 end
 

--- a/src/overloads/connectivity_tracer.jl
+++ b/src/overloads/connectivity_tracer.jl
@@ -57,7 +57,7 @@ end
 
 function connectivity_tracer_2_to_1_inner(
     px::P, py::P, is_infl_arg1_zero::Bool, is_infl_arg2_zero::Bool
-) where {P<:IndexSetVectorPattern}
+) where {P<:IndexSetGradientPattern}
     if is_infl_arg1_zero && is_infl_arg2_zero
         return myempty(P)
     elseif !is_infl_arg1_zero && is_infl_arg2_zero

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -12,12 +12,12 @@ end
 
 function gradient_tracer_1_to_1_inner(
     p::P, is_der1_zero::Bool
-) where {P<:IndexSetVectorPattern}
+) where {P<:IndexSetGradientPattern}
     return P(gradient_tracer_1_to_1_inner(set(p), is_der1_zero)) # return pattern
 end
 
 # This is only required because it is called by HessianTracer with IndexSetHessianPattern
-# Otherwise, we would just have the method on IndexSetVectorPattern above.
+# Otherwise, we would just have the method on IndexSetGradientPattern above.
 function gradient_tracer_1_to_1_inner(
     s::S, is_der1_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}
@@ -75,14 +75,14 @@ end
 
 function gradient_tracer_2_to_1_inner(
     px::P, py::P, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
-) where {P<:IndexSetVectorPattern}
+) where {P<:IndexSetGradientPattern}
     return P(
         gradient_tracer_2_to_1_inner(set(px), set(py), is_der1_arg1_zero, is_der1_arg2_zero)
     ) # return pattern
 end
 
 # This is only required because it is called by HessianTracer with IndexSetHessianPattern
-# Otherwise, we would just have the method on IndexSetVectorPattern above.
+# Otherwise, we would just have the method on IndexSetGradientPattern above.
 function gradient_tracer_2_to_1_inner(
     sx::S, sy::S, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -10,7 +10,12 @@
     end
 end
 
-# Called by HessianTracer with AbstractSet
+function gradient_tracer_1_to_1_inner(p::P, is_der1_zero::Bool) where {P<:IndexSetVector}
+    return P(gradient_tracer_1_to_1_inner(set(p), is_der1_zero)) # return pattern
+end
+
+# This is only required because it is called by HessianTracer with IndexSetHessian
+# Otherwise, we would just have the method on IndexSetVector above.
 function gradient_tracer_1_to_1_inner(
     s::S, is_der1_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}
@@ -60,12 +65,22 @@ end
         return gradient_tracer_1_to_1(ty, is_der1_arg2_zero)
     else
         g_out = gradient_tracer_2_to_1_inner(
-            gradient(tx), gradient(ty), is_der1_arg1_zero, is_der1_arg2_zero
+            pattern(tx), pattern(ty), is_der1_arg1_zero, is_der1_arg2_zero
         )
         return T(g_out) # return tracer
     end
 end
 
+function gradient_tracer_2_to_1_inner(
+    px::P, py::P, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
+) where {P<:IndexSetVector}
+    return P(
+        gradient_tracer_2_to_1_inner(set(px), set(py), is_der1_arg1_zero, is_der1_arg2_zero)
+    ) # return pattern
+end
+
+# This is only required because it is called by HessianTracer with IndexSetHessian
+# Otherwise, we would just have the method on IndexSetVector above.
 function gradient_tracer_2_to_1_inner(
     sx::S, sy::S, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -10,12 +10,14 @@
     end
 end
 
-function gradient_tracer_1_to_1_inner(p::P, is_der1_zero::Bool) where {P<:IndexSetVector}
+function gradient_tracer_1_to_1_inner(
+    p::P, is_der1_zero::Bool
+) where {P<:IndexSetVectorPattern}
     return P(gradient_tracer_1_to_1_inner(set(p), is_der1_zero)) # return pattern
 end
 
-# This is only required because it is called by HessianTracer with IndexSetHessian
-# Otherwise, we would just have the method on IndexSetVector above.
+# This is only required because it is called by HessianTracer with IndexSetHessianPattern
+# Otherwise, we would just have the method on IndexSetVectorPattern above.
 function gradient_tracer_1_to_1_inner(
     s::S, is_der1_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}
@@ -73,14 +75,14 @@ end
 
 function gradient_tracer_2_to_1_inner(
     px::P, py::P, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
-) where {P<:IndexSetVector}
+) where {P<:IndexSetVectorPattern}
     return P(
         gradient_tracer_2_to_1_inner(set(px), set(py), is_der1_arg1_zero, is_der1_arg2_zero)
     ) # return pattern
 end
 
-# This is only required because it is called by HessianTracer with IndexSetHessian
-# Otherwise, we would just have the method on IndexSetVector above.
+# This is only required because it is called by HessianTracer with IndexSetHessianPattern
+# Otherwise, we would just have the method on IndexSetVectorPattern above.
 function gradient_tracer_2_to_1_inner(
     sx::S, sy::S, is_der1_arg1_zero::Bool, is_der1_arg2_zero::Bool
 ) where {S<:AbstractSet{<:Integer}}

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -1,32 +1,32 @@
 ## 1-to-1
 
 @noinline function hessian_tracer_1_to_1(
-    t::T, is_der1_zero::Bool, is_secondder_zero::Bool
+    t::T, is_der1_zero::Bool, is_der2_zero::Bool
 ) where {T<:HessianTracer}
     if isemptytracer(t) # TODO: add test
         return t
     else
-        g_out, h_out = hessian_tracer_1_to_1_inner(
-            gradient(t), hessian(t), is_der1_zero, is_secondder_zero
-        )
-        return T(g_out, h_out) # return tracer
+        p_out = hessian_tracer_1_to_1_inner(pattern(t), is_der1_zero, is_der2_zero)
+        return T(p_out) # return tracer
     end
 end
 
 function hessian_tracer_1_to_1_inner(
-    sg::G, sh::H, is_der1_zero::Bool, is_secondder_zero::Bool
-) where {I<:Integer,G<:AbstractSet{I},H<:AbstractSet{Tuple{I,I}}}
+    p::P, is_der1_zero::Bool, is_der2_zero::Bool
+) where {I,SG,SH,P<:IndexSetHessian{I,SG,SH}}
+    sg = gradient(p)
+    sh = hessian(p)
     sg_out = gradient_tracer_1_to_1_inner(sg, is_der1_zero)
-    sh_out = if is_der1_zero && is_secondder_zero
-        myempty(H)
-    elseif !is_der1_zero && is_secondder_zero
+    sh_out = if is_der1_zero && is_der2_zero
+        myempty(SH)
+    elseif !is_der1_zero && is_der2_zero
         sh
-    elseif is_der1_zero && !is_secondder_zero
-        union_product!(myempty(H), sg, sg)
+    elseif is_der1_zero && !is_der2_zero
+        union_product!(myempty(SH), sg, sg)
     else
         union_product!(copy(sh), sg, sg)
     end
-    return sg_out, sh_out # return sets
+    return P(sg_out, sh_out) # return pattern
 end
 
 function overload_hessian_1_to_1(M, op)
@@ -62,54 +62,52 @@ end
     tx::T,
     ty::T,
     is_der1_arg1_zero::Bool,
-    is_secondder_arg1_zero::Bool,
+    is_der2_arg1_zero::Bool,
     is_der1_arg2_zero::Bool,
-    is_secondder_arg2_zero::Bool,
+    is_der2_arg2_zero::Bool,
     is_der_cross_zero::Bool,
 ) where {T<:HessianTracer}
     # TODO: add tests for isempty
     if tx.isempty && ty.isempty
         return tx # empty tracer
     elseif ty.isempty
-        return hessian_tracer_1_to_1(tx, is_der1_arg1_zero, is_secondder_arg1_zero)
+        return hessian_tracer_1_to_1(tx, is_der1_arg1_zero, is_der2_arg1_zero)
     elseif tx.isempty
-        return hessian_tracer_1_to_1(ty, is_der1_arg2_zero, is_secondder_arg2_zero)
+        return hessian_tracer_1_to_1(ty, is_der1_arg2_zero, is_der2_arg2_zero)
     else
-        g_out, h_out = hessian_tracer_2_to_1_inner(
-            gradient(tx),
-            hessian(tx),
-            gradient(ty),
-            hessian(ty),
+        p_out = hessian_tracer_2_to_1_inner(
+            pattern(tx),
+            pattern(ty),
             is_der1_arg1_zero,
-            is_secondder_arg1_zero,
+            is_der2_arg1_zero,
             is_der1_arg2_zero,
-            is_secondder_arg2_zero,
+            is_der2_arg2_zero,
             is_der_cross_zero,
         )
-        return T(g_out, h_out) # return tracer
+        return T(p_out) # return tracer
     end
 end
 
 function hessian_tracer_2_to_1_inner(
-    sgx::G,
-    shx::H,
-    sgy::G,
-    shy::H,
+    px::P,
+    py::P,
     is_der1_arg1_zero::Bool,
-    is_secondder_arg1_zero::Bool,
+    is_der2_arg1_zero::Bool,
     is_der1_arg2_zero::Bool,
-    is_secondder_arg2_zero::Bool,
+    is_der2_arg2_zero::Bool,
     is_der_cross_zero::Bool,
-) where {I<:Integer,G<:AbstractSet{I},H<:AbstractSet{Tuple{I,I}}}
+) where {I,SG,SH,P<:IndexSetHessian{I,SG,SH}}
+    sgx, shx = gradient(px), hessian(px)
+    sgy, shy = gradient(py), hessian(py)
     sg_out = gradient_tracer_2_to_1_inner(sgx, sgy, is_der1_arg1_zero, is_der1_arg2_zero)
-    sh_out = myempty(H)
+    sh_out = myempty(SH)
     !is_der1_arg1_zero && union!(sh_out, shx)  # hessian alpha
     !is_der1_arg2_zero && union!(sh_out, shy)  # hessian beta
-    !is_secondder_arg1_zero && union_product!(sh_out, sgx, sgx)  # product alpha
-    !is_secondder_arg2_zero && union_product!(sh_out, sgy, sgy)  # product beta
+    !is_der2_arg1_zero && union_product!(sh_out, sgx, sgx)  # product alpha
+    !is_der2_arg2_zero && union_product!(sh_out, sgy, sgy)  # product beta
     !is_der_cross_zero && union_product!(sh_out, sgx, sgy)  # cross product 1
     !is_der_cross_zero && union_product!(sh_out, sgy, sgx)  # cross product 2
-    return sg_out, sh_out # return sets
+    return P(sg_out, sh_out) # return pattern
 end
 
 function overload_hessian_2_to_1(M, op)

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -13,7 +13,7 @@ end
 
 function hessian_tracer_1_to_1_inner(
     p::P, is_der1_zero::Bool, is_der2_zero::Bool
-) where {I,SG,SH,P<:IndexSetHessian{I,SG,SH}}
+) where {I,SG,SH,P<:IndexSetHessianPattern{I,SG,SH}}
     sg = gradient(p)
     sh = hessian(p)
     sg_out = gradient_tracer_1_to_1_inner(sg, is_der1_zero)
@@ -96,7 +96,7 @@ function hessian_tracer_2_to_1_inner(
     is_der1_arg2_zero::Bool,
     is_der2_arg2_zero::Bool,
     is_der_cross_zero::Bool,
-) where {I,SG,SH,P<:IndexSetHessian{I,SG,SH}}
+) where {I,SG,SH,P<:IndexSetHessianPattern{I,SG,SH}}
     sgx, shx = gradient(px), hessian(px)
     sgy, shy = gradient(py), hessian(py)
     sg_out = gradient_tracer_2_to_1_inner(sgx, sgy, is_der1_arg1_zero, is_der1_arg2_zero)

--- a/src/overloads/ifelse_global.jl
+++ b/src/overloads/ifelse_global.jl
@@ -12,7 +12,7 @@
     function output_union(tx::T, ty::T) where {T<:AbstractTracer}
         return T(output_union(pattern(tx), pattern(ty))) # return tracer
     end
-    function output_union(px::P, py::P) where {P<:IndexSetVectorPattern}
+    function output_union(px::P, py::P) where {P<:IndexSetGradientPattern}
         return P(union(set(px), set(py))) # return pattern
     end
     function output_union(px::P, py::P) where {P<:IndexSetHessianPattern}

--- a/src/overloads/ifelse_global.jl
+++ b/src/overloads/ifelse_global.jl
@@ -12,10 +12,10 @@
     function output_union(tx::T, ty::T) where {T<:AbstractTracer}
         return T(output_union(pattern(tx), pattern(ty))) # return tracer
     end
-    function output_union(px::P, py::P) where {P<:IndexSetVector}
+    function output_union(px::P, py::P) where {P<:IndexSetVectorPattern}
         return P(union(set(px), set(py))) # return pattern
     end
-    function output_union(px::P, py::P) where {P<:IndexSetHessian}
+    function output_union(px::P, py::P) where {P<:IndexSetHessianPattern}
         g_out = union(gradient(px), gradient(py))
         h_out = union(hessian(px), hessian(py))
         return P(g_out, h_out) # return pattern

--- a/src/overloads/ifelse_global.jl
+++ b/src/overloads/ifelse_global.jl
@@ -9,16 +9,16 @@
     end
 
     ## output union on scalar outputs
-    function output_union(tx::T, ty::T) where {T<:ConnectivityTracer}
-        return T(union(inputs(tx), inputs(ty)))
+    function output_union(tx::T, ty::T) where {T<:AbstractTracer}
+        return T(output_union(pattern(tx), pattern(ty))) # return tracer
     end
-    function output_union(tx::T, ty::T) where {T<:GradientTracer}
-        return T(union(gradient(tx), gradient(ty)))
+    function output_union(px::P, py::P) where {P<:IndexSetVector}
+        return P(union(set(px), set(py))) # return pattern
     end
-    function output_union(tx::T, ty::T) where {T<:HessianTracer}
-        g_out = union(gradient(tx), gradient(ty))
-        h_out = union(hessian(tx), hessian(ty))
-        return T(g_out, h_out)
+    function output_union(px::P, py::P) where {P<:IndexSetHessian}
+        g_out = union(gradient(px), gradient(py))
+        h_out = union(hessian(px), hessian(py))
+        return P(g_out, h_out) # return pattern
     end
 
     output_union(tx::AbstractTracer, y) = tx

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -7,9 +7,9 @@ Abstract supertype of all sparsity pattern representations.
 ```
 AbstractPattern
 ├── AbstractVectorPattern: used in GradientTracer, ConnectivityTracer
-│   └── IndexSetVector
+│   └── IndexSetVectorPattern
 └── AbstractHessianPattern: used in HessianTracer
-    └── IndexSetHessian
+    └── IndexSetHessianPattern
 ```
 """
 AbstractPattern
@@ -85,25 +85,25 @@ Vector sparsity pattern represented by an `AbstractSet` of indices ``{i}`` of no
 ## Fields
 $(TYPEDFIELDS)
 """
-struct IndexSetVector{I<:Integer,S<:AbstractSet{I}} <: AbstractVectorPattern
+struct IndexSetVectorPattern{I<:Integer,S<:AbstractSet{I}} <: AbstractVectorPattern
     "Set of indices represting non-zero entries ``i`` in a vector."
     vector::S
 end
 
-set(v::IndexSetVector) = v.vector
+set(v::IndexSetVectorPattern) = v.vector
 
-Base.show(io::IO, s::IndexSetVector) = Base.show(io, s.vector)
+Base.show(io::IO, s::IndexSetVectorPattern) = Base.show(io, s.vector)
 
-function myempty(::Type{IndexSetVector{I,S}}) where {I,S}
-    return IndexSetVector{I,S}(myempty(S))
+function myempty(::Type{IndexSetVectorPattern{I,S}}) where {I,S}
+    return IndexSetVectorPattern{I,S}(myempty(S))
 end
-function seed(::Type{IndexSetVector{I,S}}, i) where {I,S}
-    return IndexSetVector{I,S}(seed(S, i))
+function seed(::Type{IndexSetVectorPattern{I,S}}, i) where {I,S}
+    return IndexSetVectorPattern{I,S}(seed(S, i))
 end
 
 # Tracer compatibility
-inputs(s::IndexSetVector) = s.vector
-gradient(s::IndexSetVector) = s.vector
+inputs(s::IndexSetVectorPattern) = s.vector
+gradient(s::IndexSetVectorPattern) = s.vector
 
 #========================#
 # AbstractHessianPattern #
@@ -127,23 +127,23 @@ For use with [`HessianTracer`](@ref).
 abstract type AbstractHessianPattern <: AbstractPattern end
 
 """
-    IndexSetHessian(vector::AbstractVectorPattern, mat::AbstractMatrixPattern)
+    IndexSetHessianPattern(vector::AbstractVectorPattern, mat::AbstractMatrixPattern)
 
 Gradient and Hessian sparsity patterns constructed by combining two AbstractSets.
 """
-struct IndexSetHessian{I<:Integer,SG<:AbstractSet{I},SH<:AbstractSet{Tuple{I,I}}} <:
+struct IndexSetHessianPattern{I<:Integer,SG<:AbstractSet{I},SH<:AbstractSet{Tuple{I,I}}} <:
        AbstractHessianPattern
     gradient::SG
     hessian::SH
 end
 
-function myempty(::Type{IndexSetHessian{I,SG,SH}}) where {I,SG,SH}
-    return IndexSetHessian{I,SG,SH}(myempty(SG), myempty(SH))
+function myempty(::Type{IndexSetHessianPattern{I,SG,SH}}) where {I,SG,SH}
+    return IndexSetHessianPattern{I,SG,SH}(myempty(SG), myempty(SH))
 end
-function seed(::Type{IndexSetHessian{I,SG,SH}}, index) where {I,SG,SH}
-    return IndexSetHessian{I,SG,SH}(seed(SG, index), myempty(SH))
+function seed(::Type{IndexSetHessianPattern{I,SG,SH}}, index) where {I,SG,SH}
+    return IndexSetHessianPattern{I,SG,SH}(seed(SG, index), myempty(SH))
 end
 
 # Tracer compatibility
-gradient(s::IndexSetHessian) = s.gradient
-hessian(s::IndexSetHessian) = s.hessian
+gradient(s::IndexSetHessianPattern) = s.gradient
+hessian(s::IndexSetHessianPattern) = s.hessian

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -12,25 +12,7 @@ AbstractPattern
     └── IndexSetHessianPattern
 ```
 """
-AbstractPattern
-
-"""
-    myempty(P)
-
-Constructor for an empty pattern of type `P` representing a new number (usually an empty pattern).
-"""
-myempty(::P) where {P<:AbstractPattern} = myempty(P)
-myempty(::T) where {P,T<:AbstractTracer{P}} = T(myempty(P), true)
-myempty(::Type{T}) where {P,T<:AbstractTracer{P}} = T(myempty(P), true)
-
-"""
-seed(P, i)
-
-Constructor for a pattern of type `P` that only contains the given index `i`.
-"""
-seed(::P, i) where {P<:AbstractPattern} = seed(P, i)
-seed(::T, i) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(seed(P, i))
-seed(::Type{T}, i) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(seed(P, i))
+abstract type AbstractPattern end
 
 #==========================#
 # Utilities on AbstractSet #

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -1,0 +1,147 @@
+"""
+    AbstractPattern
+
+Abstract supertype of all sparsity pattern representations.
+
+## Type hierarchy
+```
+AbstractPattern
+├── AbstractVectorPattern: used in GradientTracer, ConnectivityTracer
+│   └── IndexSetVector
+└── AbstractHessianPattern: used in HessianTracer
+    └── IndexSetHessian
+```
+"""
+AbstractPattern
+
+"""
+    myempty(P)
+
+Constructor for an empty pattern of type `P` representing a new number (usually an empty pattern).
+"""
+myempty(::P) where {P<:AbstractPattern} = myempty(P)
+myempty(::T) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(myempty(P), true)
+myempty(::Type{T}) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(myempty(P), true)
+
+"""
+seed(P, i)
+
+Constructor for a pattern of type `P` that only contains the given index `i`.
+"""
+seed(::P, i) where {P<:AbstractPattern} = seed(P, i)
+seed(::T, i) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(seed(P, i))
+seed(::Type{T}, i) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(seed(P, i))
+
+#==========================#
+# Utilities on AbstractSet #
+#==========================#
+
+myempty(::Type{S}) where {S<:AbstractSet} = S()
+seed(::Type{S}, i::Integer) where {S<:AbstractSet} = S(i)
+
+""""
+    product(a::S{T}, b::S{T})::S{Tuple{T,T}}
+
+Inner product of set-like inputs `a` and `b`.
+"""
+product(a::AbstractSet{I}, b::AbstractSet{I}) where {I<:Integer} =
+    Set((i, j) for i in a, j in b)
+
+function union_product!(
+    hessian::SH, gradient_x::SG, gradient_y::SG
+) where {I<:Integer,SG<:AbstractSet{I},SH<:AbstractSet{Tuple{I,I}}}
+    hxy = product(gradient_x, gradient_y)
+    return union!(hessian, hxy)
+end
+
+#=======================#
+# AbstractVectorPattern #
+#=======================#
+
+# For use with ConnectivityTracer and GradientTracer.
+
+"""
+    AbstractVectorPattern <: AbstractPattern
+
+Abstract supertype of sparsity patterns representing a vector.
+For use with [`ConnectivityTracer`](@ref) and [`GradientTracer`](@ref).
+
+## Expected interface
+
+* `myempty(::Type{MyPattern})`: return a pattern representing a new number (usually an empty pattern)
+* `seed(::Type{MyPattern}, i::Integer)`: return an pattern that only contains the given index `i`
+* `inputs(p::MyPattern)`: return non-zero indices `i` for use with `ConnectivityTracer`
+* `gradient(p::MyPattern)`: return non-zero indices `i` for use with `GradientTracer`
+
+Note that besides their names, the last two functions are usually identical.
+"""
+abstract type AbstractVectorPattern <: AbstractPattern end
+
+"""
+$(TYPEDEF)
+
+Vector sparsity pattern represented by an `AbstractSet` of indices ``{i}`` of non-zero values.
+
+## Fields
+$(TYPEDFIELDS)
+"""
+struct IndexSetVector{I<:Integer,S<:AbstractSet{I}} <: AbstractVectorPattern
+    "Set of indices represting non-zero entries ``i`` in a vector."
+    vector::S
+end
+
+Base.show(io::IO, s::IndexSetVector) = Base.show(io, s.vector)
+
+function myempty(::Type{IndexSetVector{I,S}}) where {I,S}
+    return IndexSetVector{I,S}(myempty(S))
+end
+function seed(::Type{IndexSetVector{I,S}}, i) where {I,S}
+    return IndexSetVector{I,S}(seed(S, i))
+end
+
+# Tracer compatibility
+inputs(s::IndexSetVector) = s.vector
+gradient(s::IndexSetVector) = s.vector
+
+#========================#
+# AbstractHessianPattern #
+#========================#
+
+# For use with HessianTracer.
+
+"""
+    AbstractHessianPattern <: AbstractPattern
+
+Abstract supertype of sparsity patterns representing both gradient and Hessian sparsity.
+For use with [`HessianTracer`](@ref).
+
+## Expected interface
+
+* `myempty(::Type{MyPattern})`: return a pattern representing a new number (usually an empty pattern)
+* `seed(::Type{MyPattern}, i::Integer)`: return an pattern that only contains the given index `i` in the first-order representation
+* `gradient(p::MyPattern)`: return non-zero indices `i` in the first-order representation
+* `hessian(p::MyPattern)`: return non-zero indices `(i, j)` in the second-order representation
+"""
+abstract type AbstractHessianPattern <: AbstractPattern end
+
+"""
+    IndexSetHessian(vector::AbstractVectorPattern, mat::AbstractMatrixPattern)
+
+Gradient and Hessian sparsity patterns constructed by combining two AbstractSets.
+"""
+struct IndexSetHessian{I<:Integer,SG<:AbstractSet{I},SH<:AbstractSet{Tuple{I,I}}} <:
+       AbstractHessianPattern
+    gradient::SG
+    hessian::SH
+end
+
+function myempty(::Type{IndexSetHessian{I,SG,SH}}) where {I,SG,SH}
+    return IndexSetHessian{I,SG,SH}(myempty(SG), myempty(SH))
+end
+function seed(::Type{IndexSetHessian{I,SG,SH}}, index) where {I,SG,SH}
+    return IndexSetHessian{I,SG,SH}(seed(SG, index), myempty(SH))
+end
+
+# Tracer compatibility
+gradient(s::IndexSetHessian) = s.gradient
+hessian(s::IndexSetHessian) = s.hessian

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -20,8 +20,8 @@ AbstractPattern
 Constructor for an empty pattern of type `P` representing a new number (usually an empty pattern).
 """
 myempty(::P) where {P<:AbstractPattern} = myempty(P)
-myempty(::T) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(myempty(P), true)
-myempty(::Type{T}) where {P<:AbstractPattern,T<:AbstractTracer{P}} = T(myempty(P), true)
+myempty(::T) where {P,T<:AbstractTracer{P}} = T(myempty(P), true)
+myempty(::Type{T}) where {P,T<:AbstractTracer{P}} = T(myempty(P), true)
 
 """
 seed(P, i)
@@ -89,6 +89,8 @@ struct IndexSetVector{I<:Integer,S<:AbstractSet{I}} <: AbstractVectorPattern
     "Set of indices represting non-zero entries ``i`` in a vector."
     vector::S
 end
+
+set(v::IndexSetVector) = v.vector
 
 Base.show(io::IO, s::IndexSetVector) = Base.show(io, s.vector)
 

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -14,7 +14,7 @@ For a higher-level interface, refer to [`connectivity_pattern`](@ref).
 ## Fields
 $(TYPEDFIELDS)
 """
-struct ConnectivityTracer{P<:AbstractVectorPattern} <: AbstractTracer{P}
+struct ConnectivityTracer{P<:AbstractGradientPattern} <: AbstractTracer{P}
     "Sparse representation of connected inputs."
     pattern::P
     "Indicator whether pattern in tracer contains only zeros."
@@ -62,7 +62,7 @@ For a higher-level interface, refer to [`jacobian_pattern`](@ref).
 ## Fields
 $(TYPEDFIELDS)
 """
-struct GradientTracer{P<:AbstractVectorPattern} <: AbstractTracer{P}
+struct GradientTracer{P<:AbstractGradientPattern} <: AbstractTracer{P}
     "Sparse representation of non-zero entries in the gradient."
     pattern::P
     "Indicator whether gradient in tracer contains only zeros."
@@ -184,14 +184,6 @@ end
 # Utilities #
 #===========#
 
-"""
-  myempty(T)
-  myempty(tracer)
-  myempty(pattern)
-
-
-Constructor for an empty tracer or pattern of type `T` representing a new number (usually an empty pattern).
-"""
 myempty(::T) where {T<:AbstractTracer} = myempty(T)
 
 # myempty(::Type{T}) where {P,T<:AbstractTracer{P}}   = T(myempty(P), true) # JET complains about this
@@ -199,13 +191,6 @@ myempty(::Type{T}) where {P,T<:ConnectivityTracer{P}} = T(myempty(P), true)
 myempty(::Type{T}) where {P,T<:GradientTracer{P}}     = T(myempty(P), true)
 myempty(::Type{T}) where {P,T<:HessianTracer{P}}      = T(myempty(P), true)
 
-"""
-  seed(T, i)
-  seed(tracer, i)
-  seed(pattern, i)
-
-Constructor for a tracer or pattern of type `T` that only contains the given index `i`.
-"""
 seed(::T, i) where {T<:AbstractTracer} = seed(T, i)
 
 # seed(::Type{T}, i) where {P,T<:AbstractTracer{P}}   = T(seed(P, i)) # JET complains about this

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -31,8 +31,9 @@ ConnectivityTracer{P}(::Real) where {P} = myempty(ConnectivityTracer{P})
 ConnectivityTracer{P}(t::ConnectivityTracer{P}) where {P} = t
 ConnectivityTracer(t::ConnectivityTracer) = t
 
-inputs(t::ConnectivityTracer) = inputs(t.pattern)
 isemptytracer(t::ConnectivityTracer) = t.isempty
+pattern(t::ConnectivityTracer) = t.pattern
+inputs(t::ConnectivityTracer) = inputs(pattern(t))
 
 function Base.show(io::IO, t::ConnectivityTracer)
     print(io, typeof(t))
@@ -74,8 +75,9 @@ GradientTracer{P}(::Real) where {P} = myempty(GradientTracer{P})
 GradientTracer{P}(t::GradientTracer{P}) where {P} = t
 GradientTracer(t::GradientTracer) = t
 
-gradient(t::GradientTracer) = gradient(t.pattern)
 isemptytracer(t::GradientTracer) = t.isempty
+pattern(t::GradientTracer) = t.pattern
+gradient(t::GradientTracer) = gradient(pattern(t))
 
 function Base.show(io::IO, t::GradientTracer)
     print(io, typeof(t))
@@ -117,9 +119,10 @@ HessianTracer{P}(::Real) where {P} = myempty(HessianTracer{P})
 HessianTracer{P}(t::HessianTracer{P}) where {P} = t
 HessianTracer(t::HessianTracer) = t
 
-gradient(t::HessianTracer) = gradient(t.pattern)
-hessian(t::HessianTracer) = hessian(t.pattern)
 isemptytracer(t::HessianTracer) = t.isempty
+pattern(t::HessianTracer) = t.pattern
+gradient(t::HessianTracer) = gradient(pattern(t))
+hessian(t::HessianTracer) = hessian(pattern(t))
 
 function Base.show(io::IO, t::HessianTracer)
     print(io, typeof(t))

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -1,3 +1,5 @@
+abstract type AbstractTracer{P<:AbstractPattern} <: Real end
+
 #====================#
 # ConnectivityTracer #
 #====================#
@@ -183,13 +185,40 @@ end
 #===========#
 
 """
+  myempty(T)
+  myempty(tracer)
+  myempty(pattern)
+
+
+Constructor for an empty tracer or pattern of type `T` representing a new number (usually an empty pattern).
+"""
+myempty(::T) where {T<:AbstractTracer} = myempty(T)
+
+# myempty(::Type{T}) where {P,T<:AbstractTracer{P}}   = T(myempty(P), true) # JET complains about this
+myempty(::Type{T}) where {P,T<:ConnectivityTracer{P}} = T(myempty(P), true)
+myempty(::Type{T}) where {P,T<:GradientTracer{P}}     = T(myempty(P), true)
+myempty(::Type{T}) where {P,T<:HessianTracer{P}}      = T(myempty(P), true)
+
+"""
+  seed(T, i)
+  seed(tracer, i)
+  seed(pattern, i)
+
+Constructor for a tracer or pattern of type `T` that only contains the given index `i`.
+"""
+seed(::T, i) where {T<:AbstractTracer} = seed(T, i)
+
+# seed(::Type{T}, i) where {P,T<:AbstractTracer{P}}   = T(seed(P, i)) # JET complains about this
+seed(::Type{T}, i) where {P,T<:ConnectivityTracer{P}} = T(seed(P, i))
+seed(::Type{T}, i) where {P,T<:GradientTracer{P}}     = T(seed(P, i))
+seed(::Type{T}, i) where {P,T<:HessianTracer{P}}      = T(seed(P, i))
+
+"""
     create_tracer(T, index) where {T<:AbstractTracer}
 
 Convenience constructor for [`ConnectivityTracer`](@ref), [`GradientTracer`](@ref) and [`HessianTracer`](@ref) from input indices.
 """
-function create_tracer(
-    ::Type{T}, ::Real, index::Integer
-) where {P<:AbstractPattern,T<:AbstractTracer{P}}
+function create_tracer(::Type{T}, ::Real, index::Integer) where {P,T<:AbstractTracer{P}}
     return T(seed(P, index))
 end
 

--- a/test/brusselator.jl
+++ b/test/brusselator.jl
@@ -22,4 +22,5 @@ end
 @testset "$T" for T in GRADIENT_TRACERS
     method = TracerSparsityDetector(; gradient_tracer_type=T)
     test_brusselator(method)
+    yield()
 end

--- a/test/brusselator.jl
+++ b/test/brusselator.jl
@@ -6,12 +6,8 @@ using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using SparseConnectivityTracerBenchmarks.ODE: Brusselator!
 using Test
 
-GRADIENT_TRACERS = (
-    GradientTracer{BitSet},
-    GradientTracer{Set{Int}},
-    GradientTracer{DuplicateVector{Int}},
-    GradientTracer{SortedVector{Int}},
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 function test_brusselator(method::AbstractSparsityDetector)
     N = 6

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -89,6 +89,7 @@ end
                 correct_classification_1_to_1(op, random_input(op); atol=DEFAULT_ATOL) for
                 _ in 1:DEFAULT_TRIALS
             )
+            yield()
         end
     end
 end;
@@ -132,6 +133,7 @@ end
                     op, random_first_input(op), random_second_input(op); atol=DEFAULT_ATOL
                 ) for _ in 1:DEFAULT_TRIALS
             )
+            yield()
         end
     end
 end;
@@ -170,6 +172,7 @@ end
                 correct_classification_1_to_2(op, random_input(op); atol=DEFAULT_ATOL) for
                 _ in 1:DEFAULT_TRIALS
             )
+            yield()
         end
     end
 end;

--- a/test/flux.jl
+++ b/test/flux.jl
@@ -6,12 +6,8 @@ using SparseConnectivityTracer
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using Test
 
-GRADIENT_TRACERS = (
-    GradientTracer{BitSet},
-    GradientTracer{Set{Int}},
-    GradientTracer{DuplicateVector{Int}},
-    GradientTracer{SortedVector{Int}},
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 const INPUT_FLUX = reshape(
     [

--- a/test/nlpmodels.jl
+++ b/test/nlpmodels.jl
@@ -67,6 +67,7 @@ hess_inconsistencies = []
             push!(hess_inconsistencies, (name, message))
         end
     end
+    yield()
 end;
 
 if !isempty(jac_inconsistencies) || !isempty(hess_inconsistencies)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,13 @@ GROUP = get(ENV, "JULIA_SCT_TEST_GROUP", "Core")
             @info "Testing formalities..."
             if VERSION >= v"1.10"
                 @testset "Code formatting" begin
+                    @info "...with JuliaFormatter.jl"
                     @test JuliaFormatter.format(
                         SparseConnectivityTracer; verbose=false, overwrite=false
                     )
                 end
                 @testset "Aqua tests" begin
+                    @info "...with Aqua.jl"
                     Aqua.test_all(
                         SparseConnectivityTracer;
                         ambiguities=false,
@@ -45,6 +47,7 @@ GROUP = get(ENV, "JULIA_SCT_TEST_GROUP", "Core")
                     )
                 end
                 @testset "JET tests" begin
+                    @info "...with JET.jl"
                     JET.test_package(SparseConnectivityTracer; target_defined_modules=true)
                 end
             end

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -18,7 +18,8 @@ TEST_SQUARE_MATRICES = Dict(
 TEST_MATRICES = merge(TEST_SQUARE_MATRICES, Dict("`Matrix` (3×4)" => rand(3, 4)))
 
 S = BitSet
-TG = GradientTracer{S}
+P = IndexSetVector{Int,S}
+TG = GradientTracer{P}
 
 # NOTE: we currently test for conservative patterns on array overloads
 # Changes making array overloads less convervative will break these tests, but are welcome!  
@@ -141,10 +142,10 @@ end
 end
 
 @testset "Matrix division" begin
-    t1 = TG(S([1, 3, 4]))
-    t2 = TG(S([2, 4]))
-    t3 = TG(S([8, 9]))
-    t4 = TG(S([8, 9]))
+    t1 = TG(P(S([1, 3, 4])))
+    t2 = TG(P(S([2, 4])))
+    t3 = TG(P(S([8, 9])))
+    t4 = TG(P(S([8, 9])))
     A = [t1 t2; t3 t4]
     s_out = S([1, 2, 3, 4, 8, 9])
 
@@ -154,10 +155,10 @@ end
 end
 
 @testset "Eigenvalues" begin
-    t1 = TG(S([1, 3, 4]))
-    t2 = TG(S([2, 4]))
-    t3 = TG(S([8, 9]))
-    t4 = TG(S([8, 9]))
+    t1 = TG(P(S([1, 3, 4])))
+    t2 = TG(P(S([2, 4])))
+    t3 = TG(P(S([8, 9])))
+    t4 = TG(P(S([8, 9])))
     A = [t1 t2; t3 t4]
     s_out = S([1, 2, 3, 4, 8, 9])
     values, vectors = eigen(A)
@@ -168,9 +169,9 @@ end
 end
 
 @testset "SparseMatrixCSC construction" begin
-    t1 = TG(S(1))
-    t2 = TG(S(2))
-    t3 = TG(S(3))
+    t1 = TG(P(S(1)))
+    t2 = TG(P(S(2)))
+    t3 = TG(P(S(3)))
     SA = sparse([t1 t2; t3 0])
     @test length(SA.nzval) == 3
 

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -18,7 +18,7 @@ TEST_SQUARE_MATRICES = Dict(
 TEST_MATRICES = merge(TEST_SQUARE_MATRICES, Dict("`Matrix` (3×4)" => rand(3, 4)))
 
 S = BitSet
-P = IndexSetVectorPattern{Int,S}
+P = IndexSetGradientPattern{Int,S}
 TG = GradientTracer{P}
 
 # NOTE: we currently test for conservative patterns on array overloads

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -18,7 +18,7 @@ TEST_SQUARE_MATRICES = Dict(
 TEST_MATRICES = merge(TEST_SQUARE_MATRICES, Dict("`Matrix` (3×4)" => rand(3, 4)))
 
 S = BitSet
-P = IndexSetVector{Int,S}
+P = IndexSetVectorPattern{Int,S}
 TG = GradientTracer{P}
 
 # NOTE: we currently test for conservative patterns on array overloads

--- a/test/test_connectivity.jl
+++ b/test/test_connectivity.jl
@@ -1,17 +1,12 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer: ConnectivityTracer, Dual, MissingPrimalError, trace_input
-using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using LinearAlgebra: det, dot, logdet
 using SpecialFunctions: erf, beta
 using NNlib: NNlib
 using Test
 
-CONNECTIVITY_TRACERS = (
-    ConnectivityTracer{BitSet},
-    ConnectivityTracer{Set{Int}},
-    ConnectivityTracer{DuplicateVector{Int}},
-    ConnectivityTracer{SortedVector{Int}},
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 NNLIB_ACTIVATIONS_S = (
     NNlib.σ,

--- a/test/test_connectivity.jl
+++ b/test/test_connectivity.jl
@@ -116,6 +116,7 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
         @test_throws TypeError connectivity_pattern(
             x -> x[1] > x[2] ? x[3] : x[4], [1.0, 2.0, 3.0, 4.0], T
         ) == [0 0 1 1;]
+        yield()
     end
 end
 
@@ -128,5 +129,6 @@ end
             x -> ifelse(x[2] < x[3], x[1] + x[2], x[3] * x[4]), [1 3 2 4], T
         ) == [0 0 1 1]
         @test local_connectivity_pattern(x -> 0, 1, T) ≈ [0;;]
+        yield()
     end
 end

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -1,35 +1,12 @@
 # Test construction and conversions of internal tracer types
 using SparseConnectivityTracer:
     AbstractTracer, ConnectivityTracer, GradientTracer, HessianTracer, Dual
-using SparseConnectivityTracer: IndexSetVector, IndexSetHessian
 using SparseConnectivityTracer: inputs, primal, tracer, isemptytracer
 using SparseConnectivityTracer: myempty, name
-using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using Test
 
-CONNECTIVITY_TRACERS = (
-    ConnectivityTracer{IndexSetVector{Int,BitSet}},
-    ConnectivityTracer{IndexSetVector{Int,Set{Int}}},
-    ConnectivityTracer{IndexSetVector{Int,DuplicateVector{Int}}},
-    ConnectivityTracer{IndexSetVector{Int,SortedVector{Int}}},
-)
-
-GRADIENT_TRACERS = (
-    GradientTracer{IndexSetVector{Int,BitSet}},
-    GradientTracer{IndexSetVector{Int,Set{Int}}},
-    GradientTracer{IndexSetVector{Int,DuplicateVector{Int}}},
-    GradientTracer{IndexSetVector{Int,SortedVector{Int}}},
-)
-
-HESSIAN_TRACERS = (
-    HessianTracer{IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}}},
-    HessianTracer{IndexSetHessian{Int,Set{Int},Set{Tuple{Int,Int}}}},
-    HessianTracer{
-        IndexSetHessian{Int,DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}}
-    },
-    HessianTracer{IndexSetHessian{Int,SortedVector{Int},SortedVector{Tuple{Int,Int}}}},
-    # TODO: test on RecursiveSet
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 function test_nested_duals(::Type{T}) where {T<:AbstractTracer}
     # Putting Duals into Duals is prohibited

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -1,30 +1,33 @@
 # Test construction and conversions of internal tracer types
 using SparseConnectivityTracer:
     AbstractTracer, ConnectivityTracer, GradientTracer, HessianTracer, Dual
+using SparseConnectivityTracer: IndexSetVector, IndexSetHessian
 using SparseConnectivityTracer: inputs, primal, tracer, isemptytracer
 using SparseConnectivityTracer: myempty, name
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using Test
 
 CONNECTIVITY_TRACERS = (
-    ConnectivityTracer{BitSet},
-    ConnectivityTracer{Set{Int}},
-    ConnectivityTracer{DuplicateVector{Int}},
-    ConnectivityTracer{SortedVector{Int}},
+    ConnectivityTracer{IndexSetVector{Int,BitSet}},
+    ConnectivityTracer{IndexSetVector{Int,Set{Int}}},
+    ConnectivityTracer{IndexSetVector{Int,DuplicateVector{Int}}},
+    ConnectivityTracer{IndexSetVector{Int,SortedVector{Int}}},
 )
 
 GRADIENT_TRACERS = (
-    GradientTracer{BitSet},
-    GradientTracer{Set{Int}},
-    GradientTracer{DuplicateVector{Int}},
-    GradientTracer{SortedVector{Int}},
+    GradientTracer{IndexSetVector{Int,BitSet}},
+    GradientTracer{IndexSetVector{Int,Set{Int}}},
+    GradientTracer{IndexSetVector{Int,DuplicateVector{Int}}},
+    GradientTracer{IndexSetVector{Int,SortedVector{Int}}},
 )
 
 HESSIAN_TRACERS = (
-    HessianTracer{BitSet,Set{Tuple{Int,Int}}},
-    HessianTracer{Set{Int},Set{Tuple{Int,Int}}},
-    HessianTracer{DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}},
-    HessianTracer{SortedVector{Int},SortedVector{Tuple{Int,Int}}},
+    HessianTracer{IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}}},
+    HessianTracer{IndexSetHessian{Int,Set{Int},Set{Tuple{Int,Int}}}},
+    HessianTracer{
+        IndexSetHessian{Int,DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}}
+    },
+    HessianTracer{IndexSetHessian{Int,SortedVector{Int},SortedVector{Tuple{Int,Int}}}},
     # TODO: test on RecursiveSet
 )
 

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -125,6 +125,7 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
         @test_throws TypeError jacobian_sparsity(
             x -> x[1] > x[2] ? x[3] : x[4], [1.0, 2.0, 3.0, 4.0], method
         ) == [0 0 1 1;]
+        yield()
     end
 end
 
@@ -249,5 +250,6 @@ end
         @test jacobian_sparsity(NNlib.softshrink, -1, method) ≈ [1;;]
         @test jacobian_sparsity(NNlib.softshrink, 0, method) ≈ [0;;]
         @test jacobian_sparsity(NNlib.softshrink, 1, method) ≈ [1;;]
+        yield()
     end
 end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -1,18 +1,13 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer: GradientTracer, Dual, MissingPrimalError, trace_input
-using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using ADTypes: jacobian_sparsity
 using LinearAlgebra: det, dot, logdet
 using SpecialFunctions: erf, beta
 using NNlib: NNlib
 using Test
 
-GRADIENT_TRACERS = (
-    GradientTracer{BitSet},
-    GradientTracer{Set{Int}},
-    GradientTracer{DuplicateVector{Int}},
-    GradientTracer{SortedVector{Int}},
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 NNLIB_ACTIVATIONS_S = (
     NNlib.σ,

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -208,6 +208,7 @@ include("tracers_definitions.jl")
             1 1 0
             0 0 0
         ]
+        yield()
     end
 end
 
@@ -262,5 +263,6 @@ end
         @test hessian_sparsity(x -> (2//3)^zero(x), 1, method) ≈ [0;;]
         @test hessian_sparsity(x -> zero(x)^ℯ, 1, method) ≈ [0;;]
         @test hessian_sparsity(x -> ℯ^zero(x), 1, method) ≈ [0;;]
+        yield()
     end
 end

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -1,17 +1,11 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer: Dual, HessianTracer, MissingPrimalError, trace_input, empty
-using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 using ADTypes: hessian_sparsity
 using SpecialFunctions: erf, beta
 using Test
 
-HESSIAN_TRACERS = (
-    HessianTracer{BitSet,Set{Tuple{Int,Int}}},
-    HessianTracer{Set{Int},Set{Tuple{Int,Int}}},
-    HessianTracer{DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}},
-    HessianTracer{SortedVector{Int},SortedVector{Tuple{Int,Int}}},
-    # TODO: test on RecursiveSet
-)
+# Load definitions of CONNECTIVITY_TRACERS, GRADIENT_TRACERS, HESSIAN_TRACERS
+include("tracers_definitions.jl")
 
 @testset "Global Hessian" begin
     @testset "Default hessian_pattern" begin

--- a/test/tracers_definitions.jl
+++ b/test/tracers_definitions.jl
@@ -1,0 +1,23 @@
+using SparseConnectivityTracer:
+    AbstractTracer, ConnectivityTracer, GradientTracer, HessianTracer, Dual
+using SparseConnectivityTracer: IndexSetVector, IndexSetHessian
+using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
+
+VECTOR_PATTERNS = (
+    IndexSetVector{Int,BitSet},
+    IndexSetVector{Int,Set{Int}},
+    IndexSetVector{Int,DuplicateVector{Int}},
+    IndexSetVector{Int,SortedVector{Int}},
+)
+
+HESSIAN_PATTERNS = (
+    IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}},
+    IndexSetHessian{Int,Set{Int},Set{Tuple{Int,Int}}},
+    IndexSetHessian{Int,DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}},
+    IndexSetHessian{Int,SortedVector{Int},SortedVector{Tuple{Int,Int}}},
+    # TODO: test on RecursiveSet
+)
+
+CONNECTIVITY_TRACERS = (ConnectivityTracer{P} for P in VECTOR_PATTERNS)
+GRADIENT_TRACERS = (GradientTracer{P} for P in VECTOR_PATTERNS)
+HESSIAN_TRACERS = (HessianTracer{P} for P in HESSIAN_PATTERNS)

--- a/test/tracers_definitions.jl
+++ b/test/tracers_definitions.jl
@@ -1,13 +1,13 @@
 using SparseConnectivityTracer:
     AbstractTracer, ConnectivityTracer, GradientTracer, HessianTracer, Dual
-using SparseConnectivityTracer: IndexSetVectorPattern, IndexSetHessianPattern
+using SparseConnectivityTracer: IndexSetGradientPattern, IndexSetHessianPattern
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 
 VECTOR_PATTERNS = (
-    IndexSetVectorPattern{Int,BitSet},
-    IndexSetVectorPattern{Int,Set{Int}},
-    IndexSetVectorPattern{Int,DuplicateVector{Int}},
-    IndexSetVectorPattern{Int,SortedVector{Int}},
+    IndexSetGradientPattern{Int,BitSet},
+    IndexSetGradientPattern{Int,Set{Int}},
+    IndexSetGradientPattern{Int,DuplicateVector{Int}},
+    IndexSetGradientPattern{Int,SortedVector{Int}},
 )
 
 HESSIAN_PATTERNS = (

--- a/test/tracers_definitions.jl
+++ b/test/tracers_definitions.jl
@@ -1,20 +1,20 @@
 using SparseConnectivityTracer:
     AbstractTracer, ConnectivityTracer, GradientTracer, HessianTracer, Dual
-using SparseConnectivityTracer: IndexSetVector, IndexSetHessian
+using SparseConnectivityTracer: IndexSetVectorPattern, IndexSetHessianPattern
 using SparseConnectivityTracer: DuplicateVector, RecursiveSet, SortedVector
 
 VECTOR_PATTERNS = (
-    IndexSetVector{Int,BitSet},
-    IndexSetVector{Int,Set{Int}},
-    IndexSetVector{Int,DuplicateVector{Int}},
-    IndexSetVector{Int,SortedVector{Int}},
+    IndexSetVectorPattern{Int,BitSet},
+    IndexSetVectorPattern{Int,Set{Int}},
+    IndexSetVectorPattern{Int,DuplicateVector{Int}},
+    IndexSetVectorPattern{Int,SortedVector{Int}},
 )
 
 HESSIAN_PATTERNS = (
-    IndexSetHessian{Int,BitSet,Set{Tuple{Int,Int}}},
-    IndexSetHessian{Int,Set{Int},Set{Tuple{Int,Int}}},
-    IndexSetHessian{Int,DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}},
-    IndexSetHessian{Int,SortedVector{Int},SortedVector{Tuple{Int,Int}}},
+    IndexSetHessianPattern{Int,BitSet,Set{Tuple{Int,Int}}},
+    IndexSetHessianPattern{Int,Set{Int},Set{Tuple{Int,Int}}},
+    IndexSetHessianPattern{Int,DuplicateVector{Int},DuplicateVector{Tuple{Int,Int}}},
+    IndexSetHessianPattern{Int,SortedVector{Int},SortedVector{Tuple{Int,Int}}},
     # TODO: test on RecursiveSet
 )
 


### PR DESCRIPTION
This is the second attempt at #114 after #119 got derailed by unrelated compile time issues.

___

This PR introduces `AbstractPattern`s that represent sparsity patterns:
```
AbstractPattern
├── AbstractVectorPattern: used in GradientTracer, ConnectivityTracer
│   └── IndexSetVectorPattern
└── AbstractHessianPattern: used in HessianTracer
    └── IndexSetHessianPattern
```

Over the last dozens of PRs, we've kept refactoring the Tracer type signatures to accommodate new representations for sparse vectors and sparse matrices, most notably:
* moving away from shared first- and second-order information that were dictionaries of sets (#57)
* introducing custom data types, which had to be forced into the `AbstractSet` interface (#50)
* making second-order information more generic (#103)
* potentially adding traits for shared tracers (#135)

Advantages of introducing pattern types:
* It makes prototyping new ideas like #137 much faster, since tracer types don't have to be touched.
* It allows for the reintroduction of `DictHessianPattern`s, which can't be split into `gradient` and `hessian` fields.  
* PR #135 showed that dispatching on generic field types such as `AbstractSet` isn't enough, since `AbstractSet`s can be used in an allocating or non-allocating manner. 
In 135, the proposed workaround was to introduce a new field to the `HessianTracer` struct. This is problematic for several reasons:
  * It is harder to document than pattern structs, which have individual docstrings
  * If we support new field types, like #137, it implies that we always need to implement and maintain two variants, one that allocates and one that mutates
  * If the point above is circumvented, e.g. by using strict inner constructors, this once again puts burden on the documentation and/or users.

Recommended reading order for reviews:
1. `patterns.jl`
1. `tracers.jl` 
1. updated overload files