### PR TITLE
Support `isless`

### DIFF
--- a/src/overloads/dual.jl
+++ b/src/overloads/dual.jl
@@ -5,6 +5,7 @@ for fn in (
     :isfinite,
     :isinf,
     :isinteger,
+    :isless,
     :ismissing,
     :isnan,
     :isnothing,

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -82,6 +82,7 @@ NNLIB_ACTIVATIONS = union(NNLIB_ACTIVATIONS_S, NNLIB_ACTIVATIONS_F)
             isfinite,
             isinf,
             isinteger,
+            isless,
             ismissing,
             isnan,
             isnothing,

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -179,6 +179,7 @@ include("tracers_definitions.jl")
             isfinite,
             isinf,
             isinteger,
+            isless,
             ismissing,
             isnan,
             isnothing,


### PR DESCRIPTION
Address https://github.com/adrhill/SparseConnectivityTracer.jl/issues/145#issuecomment-2271749831 by adding support for `isless` on `TracerLocalSparsityDetector`.