### PR TITLE
Smaller benchmarks

### DIFF
--- a/benchmark/bench_jogger.jl
+++ b/benchmark/bench_jogger.jl
@@ -18,7 +18,11 @@ suite["Hessian"]["Global"] = hessbench(TracerSparsityDetector())
 suite["Hessian"]["Local"] = hessbench(TracerLocalSparsityDetector())
 
 # Shared tracers 
-PH = DictHessianPattern{Int,BitSet,Dict{Int,BitSet},Shared}
-H = HessianTracer{PH}
-method = TracerSparsityDetector(; hessian_tracer_type=H)
-suite["Hessian"]["Global (shared)"] = hessbench(method)
+P = DictHessianPattern{Int,BitSet,Dict{Int,BitSet},Shared}
+H = HessianTracer{P}
+suite["Hessian"]["Global shared"] = hessbench(
+    TracerSparsityDetector(; hessian_tracer_type=H)
+)
+suite["Hessian"]["Local shared"] = hessbench(
+    TracerLocalSparsityDetector(; hessian_tracer_type=H)
+)

--- a/benchmark/nlpmodels.jl
+++ b/benchmark/nlpmodels.jl
@@ -7,10 +7,8 @@ function optbench(names::Vector{Symbol})
     suite = BenchmarkGroup()
     for name in names
         nlp = ADNLPProblems.eval(name)()
-        suite[name]["Jacobian"] = @benchmarkable compute_jac_sparsity_sct($nlp) evals = 1 samples =
-            1
-        suite[name]["Hessian"] = @benchmarkable compute_hess_sparsity_sct($nlp) evals = 1 samples =
-            1
+        suite[name]["Jacobian"] = @benchmarkable compute_jac_sparsity_sct($nlp)
+        suite[name]["Hessian"] = @benchmarkable compute_hess_sparsity_sct($nlp)
     end
     return suite
 end


### PR DESCRIPTION
In recent PRs, we've never needed to benchmark the performance of individual set types.
At this point in development, we should focus on benchmarks of our defaults instead. The only exception in this PR are shared Hessian tracers, which don't have a public API yet.