### PR TITLE
Use `DictHessianPattern` as default tracer pattern

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,6 +1,6 @@
 const DEFAULT_GRADIENT_TRACER = GradientTracer{IndexSetGradientPattern{Int,BitSet}}
 const DEFAULT_HESSIAN_TRACER = HessianTracer{
-    IndexSetHessianPattern{Int,BitSet,Set{Tuple{Int,Int}},NotShared}
+    DictHessianPattern{Int,BitSet,Dict{Int,BitSet},NotShared}
 }
 
 #==================#


### PR DESCRIPTION
Default to new `DictHessianPattern` from #155 for Hessian tracing.

With the updated benchmarks from #157, #159, #160 in place, the CI benchmarks will now compare the performance of both the old and new default.