### PR TITLE
Remove randomness from benchmarks

### DIFF
--- a/benchmark/hessian.jl
+++ b/benchmark/hessian.jl
@@ -1,9 +1,7 @@
 using BenchmarkTools
-
-using ADTypes: hessian_sparsity
 using SparseConnectivityTracer
 
-using SparseArrays: sprand
+using Random: MersenneTwister
 
 #=
 Test cases taken from the article:
@@ -62,7 +60,7 @@ struct RandomSparsity
 end
 
 function RandomSparsity(N::Integer, K::Integer)
-    rand_sets = [rand(1:N, K) for i in 1:N]
+    rand_sets = [rand(MersenneTwister(123 + i), 1:N, K) for i in 1:N]
     return RandomSparsity(rand_sets)
 end
 

--- a/benchmark/jacobian.jl
+++ b/benchmark/jacobian.jl
@@ -1,9 +1,8 @@
 using BenchmarkTools
-
-using ADTypes: AbstractSparsityDetector, jacobian_sparsity
 using SparseConnectivityTracer
 using SparseConnectivityTracerBenchmarks.ODE: Brusselator!, brusselator_2d_loop!
 
+using Random: MersenneTwister
 using SparseArrays: sprand
 using SimpleDiffEq: ODEProblem, solve, SimpleEuler
 using Flux: Conv
@@ -23,7 +22,7 @@ struct IteratedSparseMul{M<:AbstractMatrix}
 end
 
 function IteratedSparseMul(; n::Integer, p::Real=0.1, depth::Integer=5)
-    As = [sprand(n, n, p) for _ in 1:depth]
+    As = [sprand(MersenneTwister(123 + i), n, n, p) for i in 1:depth]
     return IteratedSparseMul(As)
 end
 


### PR DESCRIPTION
The randomness had such a big influence on the sparsity patterns that the benchmark outcomes were random.