### PR TITLE
Increase sparsity for `Diagonal` inputs

### DIFF
--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -6,7 +6,8 @@ using SparseArrays: SparseArrays
 using SparseArrays: sparse
 using Random: AbstractRNG, SamplerType
 
-using LinearAlgebra: LinearAlgebra, Symmetric, Diagonal
+using LinearAlgebra: LinearAlgebra, Symmetric
+using LinearAlgebra: Diagonal, diag, diagind
 using FillArrays: Fill
 
 using DocStringExtensions

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,12 +21,16 @@ trace_input(::Type{T}, xs) where {T<:Union{AbstractTracer,Dual}} = trace_input(T
 # e.g. on `Symmetric`, where symmetry doesn't hold for the index matrix.
 allocate_index_matrix(A::AbstractArray) = similar(A, Int)
 allocate_index_matrix(A::Symmetric) = Matrix{Int}(undef, size(A)...)
-allocate_index_matrix(A::Diagonal) = Matrix{Int}(undef, size(A)...)
 
 function trace_input(::Type{T}, xs::AbstractArray, i) where {T<:Union{AbstractTracer,Dual}}
     is = allocate_index_matrix(xs)
     is .= reshape(1:length(xs), size(xs)) .+ (i - 1)
     return create_tracers(T, xs, is)
+end
+
+function trace_input(::Type{T}, xs::Diagonal, i) where {T<:Union{AbstractTracer,Dual}}
+    ts = create_tracers(T, diag(xs), diagind(xs))
+    return Diagonal(ts)
 end
 
 function trace_input(::Type{T}, x::Real, i::Integer) where {T<:Union{AbstractTracer,Dual}}

--- a/src/overloads/arrays.jl
+++ b/src/overloads/arrays.jl
@@ -162,6 +162,12 @@ function LinearAlgebra.:^(A::AbstractMatrix{T}, p::Integer) where {T<:AbstractTr
     end
 end
 
+function Base.literal_pow(::typeof(^), D::Diagonal{T}, ::Val{0}) where {T<:AbstractTracer}
+    ts = similar(D.diag)
+    ts .= myempty(T)
+    return Diagonal(ts)
+end
+
 #==========================#
 # LinearAlgebra.jl on Dual #
 #==========================#

--- a/src/overloads/arrays.jl
+++ b/src/overloads/arrays.jl
@@ -116,6 +116,15 @@ function LinearAlgebra.inv(A::StridedMatrix{T}) where {T<:AbstractTracer}
     t = second_order_or(A)
     return Fill(t, size(A)...)
 end
+function LinearAlgebra.inv(D::Diagonal{T}) where {T<:AbstractTracer}
+    ts_in = D.diag
+    ts_out = similar(ts_in)
+    for i in 1:length(ts_out)
+        ts_out[i] = inv(ts_in[i])
+    end
+    return Diagonal(ts_out)
+end
+
 function LinearAlgebra.pinv(
     A::AbstractMatrix{T}; atol::Real=0.0, rtol::Real=0.0
 ) where {T<:AbstractTracer}
@@ -123,6 +132,7 @@ function LinearAlgebra.pinv(
     t = second_order_or(A)
     return Fill(t, m, n)
 end
+LinearAlgebra.pinv(D::Diagonal{T}) where {T<:AbstractTracer} = LinearAlgebra.inv(D)
 
 ## Division
 function LinearAlgebra.:\(

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -47,15 +47,19 @@ pow3(A) = A^3
 
 method = TracerSparsityDetector()
 
-test_all_one(A) = @test all(isone, A)
-test_all_zero(A) = @test all(iszero, A)
+allone(A) = all(isone, A)
+allzero(A) = all(iszero, A)
 
 # Short-hand for Jacobian pattern of `x -> sum(f(A))`
 Jsum(f, A) = jacobian_sparsity(SumOutputs(f), A, method)
 # Test whether all entries in Jacobian are zero
-testJ0(f, A) = @testset "Jacobian" test_all_zero(Jsum(f, A))
+testJ0(f, A) = @testset "Jacobian" begin
+    @test allzero(Jsum(f, A))
+end
 # Test whether all entries in Jacobian are one where inputs were non-zero.
-testJ1(f, A) = @testset "Jacobian" test_all_one(Jsum(f, A))
+testJ1(f, A) = @testset "Jacobian" begin
+    @test allone(Jsum(f, A))
+end
 function testJ1(f, A::Diagonal)
     @testset "Jacobian" begin
         jac = Jsum(f, A)
@@ -73,9 +77,13 @@ end
 # Short-hand for Hessian pattern of `x -> sum(f(A))`
 Hsum(f, A) = hessian_sparsity(SumOutputs(f), A, method)
 # Test whether all entries in Hessian are zero
-testH0(f, A) = @testset "Hessian" test_all_zero(Hsum(f, A))
+testH0(f, A) = @testset "Hessian" begin
+    @test allzero(Hsum(f, A))
+end
 # Test whether all entries in Hessian are one where inputs were non-zero.
-testH1(f, A) = @testset "Hessian" test_all_one(Hsum(f, A))
+testH1(f, A) = @testset "Hessian" begin
+    @test allone(Hsum(f, A))
+end
 function testH1(f, A::Diagonal)
     @testset "Hessian" begin
         hess = Hsum(f, A)

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -29,6 +29,18 @@ struct SumOutputs{F}
     f::F
 end
 (s::SumOutputs)(x) = sum(s.f(x))
+
+norm1(A) = norm(A, 1)
+norm2(A) = norm(A, 2)
+norminf(A) = norm(A, Inf)
+opnorm1(A) = opnorm(A, 1)
+opnorm2(A) = opnorm(A, 2)
+opnorminf(A) = opnorm(A, Inf)
+logabsdet_first(A) = first(logabsdet(A))
+logabsdet_last(A) = last(logabsdet(A))
+pow0(A) = A^0
+pow3(A) = A^3
+
 #===================#
 # Testing utilities #
 #===================#
@@ -105,15 +117,6 @@ arrayname(A) = "$(typeof(A)) $(size(A))"
 #=================#
 
 @testset "Scalar functions" begin
-    norm1(A) = norm(A, 1)
-    norm2(A) = norm(A, 2)
-    norminf(A) = norm(A, Inf)
-    opnorm1(A) = opnorm(A, 1)
-    opnorm2(A) = opnorm(A, 2)
-    opnorminf(A) = opnorm(A, Inf)
-    logabsdet_first(A) = first(logabsdet(A))
-    logabsdet_last(A) = last(logabsdet(A))
-
     @testset "det $(arrayname(A))" for A in NONDIAG_MATRICES
         testJ1(det, A)
         testH1(det, A)
@@ -236,9 +239,6 @@ arrayname(A) = "$(typeof(A)) $(size(A))"
 end
 
 @testset "Matrix-valued functions" begin
-    pow0(A) = A^0
-    pow3(A) = A^3
-
     # Functions that only work on square matrices
     @testset "inv $(arrayname(A))" for A in NONDIAG_SQUARE_MATRICES
         testJ1(inv, A)
@@ -275,14 +275,9 @@ end
             0  0  0  0  0  0  0  0  1
         ]
     end
-    @testset "pow0 $(arrayname(A))" for A in NONDIAG_SQUARE_MATRICES
+    @testset "pow0 $(arrayname(A))" for A in SQUARE_MATRICES
         testJ0(pow0, A)
         testH0(pow0, A)
-    end
-    @testset "pow0 $(arrayname(A))" for A in DIAG_SQUARE_MATRICES
-        # TODO: these should be zero and are currently too conservative
-        @test_broken all(iszero, Jsum(pow0, A))
-        @test_broken all(iszero, Hsum(pow0, A))
     end
     @testset "pow3 $(arrayname(A))" for A in SQUARE_MATRICES
         testJ1(pow3, A)


### PR DESCRIPTION
By having `trace_input` create a `Diagonal` matrix of tracers with only the indices from `diagind`, the sparsity of patterns can be increased by a lot on `Diagonal` inputs:

<img width="507" alt="image" src="https://github.com/user-attachments/assets/bd3044fe-f7c7-42ea-9b62-df30a889ff35">

Previously, this would have returned a dense pattern of ones (see #147).