### PR TITLE
Add direct type conversion on `Dual`

### DIFF
--- a/src/overloads/conversion.jl
+++ b/src/overloads/conversion.jl
@@ -50,6 +50,14 @@ function Base.convert(::Type{Dual{P1,T}}, d::Dual{P2,T}) where {P1,P2,T}
     return Dual(convert(P1, primal(d)), tracer(d))
 end
 
+# Explicit type conversions
+for T in (:Int, :Integer, :Float64, :Float32)
+    @eval function Base.$T(d::Dual)
+        isemptytracer(d) || throw(InexactError(Symbol($T), $T, d))
+        $T(primal(d))
+    end
+end
+
 ## Constants
 # These are methods defined on types. Methods on variables are in operators.jl 
 Base.zero(::Type{D})        where {P,T,D<:Dual{P,T}} = D(zero(P),        myempty(T))

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -143,9 +143,9 @@ function union_product!(
     return hessian
 end
 
-#=======================#
+#=========================#
 # AbstractGradientPattern #
-#=======================#
+#=========================#
 
 # For use with GradientTracer.
 

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -9,11 +9,16 @@ using NNlib: NNlib
 
 # Load definitions of GRADIENT_TRACERS, GRADIENT_PATTERNS, HESSIAN_TRACERS and HESSIAN_PATTERNS
 include("tracers_definitions.jl")
+REAL_TYPES = (Float64, Int, Bool, UInt8, Float16, Rational{Int})
 
-# This exists to be able to quickly run tests in the REPL.
+# These exists to be able to quickly run tests in the REPL.
 # NOTE: H gets overwritten inside the testsets.
 method = TracerSparsityDetector()
 H(f, x) = hessian_sparsity(f, x, method)
+
+P = first(HESSIAN_PATTERNS)
+T = HessianTracer{P}
+D = Dual{Int,T}
 
 @testset "Global Hessian" begin
     @testset "$P" for P in HESSIAN_PATTERNS


### PR DESCRIPTION
Closes #164 by supporting:
* `Int(d::Dual)`
* `Integer(d::Dual)`
* `Float64(d::Dual)`
* `Float32(d::Dual)`

This currently throws an `InexactError` when tracers are not empty. This is analogous to [ForwardDiff's approach](https://github.com/JuliaDiff/ForwardDiff.jl/blob/a286920bb5e401c8dc5d09589c9764d37cf5c6d2/src/dual.jl#L358-L365).

Depending on the outcome of the ongoing discussion in #167, we might want to make this less conservative for `Int(d)` and `Integer(d)` in the future.