### PR TITLE
Refactor type conversions

### DIFF
--- a/src/overloads/conversion.jl
+++ b/src/overloads/conversion.jl
@@ -1,81 +1,67 @@
-#! format: off
-
 ##===============#
 # AbstractTracer #
 #================#
 
-## Type conversions (non-dual)
 Base.promote_rule(::Type{T}, ::Type{N}) where {T<:AbstractTracer,N<:Real} = T
 Base.promote_rule(::Type{N}, ::Type{T}) where {T<:AbstractTracer,N<:Real} = T
 
-Base.big(::Type{T})   where {T<:AbstractTracer} = T
-Base.widen(::Type{T}) where {T<:AbstractTracer} = T
-Base.float(::Type{T}) where {T<:AbstractTracer} = T
-
-Base.convert(::Type{T}, x::Real)   where {T<:AbstractTracer} = myempty(T)
-Base.convert(::Type{T}, t::T)      where {T<:AbstractTracer} = t
+Base.convert(::Type{T}, x::Real) where {T<:AbstractTracer}   = myempty(T)
+Base.convert(::Type{T}, t::T) where {T<:AbstractTracer}      = t
 Base.convert(::Type{<:Real}, t::T) where {T<:AbstractTracer} = t
-
-## Constants
-# These are methods defined on types. Methods on variables are in operators.jl 
-Base.zero(::Type{T})        where {T<:AbstractTracer} = myempty(T)
-Base.one(::Type{T})         where {T<:AbstractTracer} = myempty(T)
-Base.oneunit(::Type{T})     where {T<:AbstractTracer} = myempty(T)
-Base.typemin(::Type{T})     where {T<:AbstractTracer} = myempty(T)
-Base.typemax(::Type{T})     where {T<:AbstractTracer} = myempty(T)
-Base.eps(::Type{T})         where {T<:AbstractTracer} = myempty(T)
-Base.floatmin(::Type{T})    where {T<:AbstractTracer} = myempty(T)
-Base.floatmax(::Type{T})    where {T<:AbstractTracer} = myempty(T)
-Base.maxintfloat(::Type{T}) where {T<:AbstractTracer} = myempty(T)
 
 ##======#
 # Duals #
 #=======#
 
-function Base.promote_rule(::Type{Dual{P1, T}}, ::Type{Dual{P2, T}}) where {P1,P2,T}
+function Base.promote_rule(::Type{Dual{P1,T}}, ::Type{Dual{P2,T}}) where {P1,P2,T}
     PP = Base.promote_type(P1, P2) # TODO: possible method call error?
     return Dual{PP,T}
 end
-function Base.promote_rule(::Type{Dual{P, T}}, ::Type{N}) where {P,T,N<:Real}
+function Base.promote_rule(::Type{Dual{P,T}}, ::Type{N}) where {P,T,N<:Real}
     PP = Base.promote_type(P, N) # TODO: possible method call error?
     return Dual{PP,T}
 end
-function Base.promote_rule(::Type{N}, ::Type{Dual{P, T}}) where {P,T,N<:Real}
+function Base.promote_rule(::Type{N}, ::Type{Dual{P,T}}) where {P,T,N<:Real}
     PP = Base.promote_type(P, N) # TODO: possible method call error?
     return Dual{PP,T}
 end
 
-Base.big(::Type{D})   where {P,T,D<:Dual{P,T}} = Dual{big(P),T}
-Base.widen(::Type{D}) where {P,T,D<:Dual{P,T}} = Dual{widen(P),T}
-Base.float(::Type{D}) where {P,T,D<:Dual{P,T}} = Dual{float(P),T}
+Base.convert(::Type{D}, x::Real) where {P,T,D<:Dual{P,T}}      = Dual(x, myempty(T))
+Base.convert(::Type{D}, d::D) where {P,T,D<:Dual{P,T}}         = d
+Base.convert(::Type{N}, d::D) where {N<:Real,P,T,D<:Dual{P,T}} = Dual(convert(N, primal(d)), tracer(d))
 
-Base.convert(::Type{D}, x::Real) where {P,T,D<:Dual{P,T}}           = Dual(x, myempty(T))
-Base.convert(::Type{D}, d::D)    where {P,T,D<:Dual{P,T}}           = d
-Base.convert(::Type{N}, d::D)    where {N<:Real,P,T,D<:Dual{P,T}}   = Dual(convert(N, primal(d)), tracer(d))
-
-function Base.convert(::Type{Dual{P1,T}}, d::Dual{P2,T}) where {P1,P2,T} 
+function Base.convert(::Type{Dual{P1,T}}, d::Dual{P2,T}) where {P1,P2,T}
     return Dual(convert(P1, primal(d)), tracer(d))
 end
 
-# Explicit type conversions
+##==========================#
+# Explicit type conversions #
+#===========================#
+
 for T in (:Int, :Integer, :Float64, :Float32)
+    # Currently only defined on Dual to avoid invalidations.
     @eval function Base.$T(d::Dual)
         isemptytracer(d) || throw(InexactError(Symbol($T), $T, d))
-        $T(primal(d))
+        return $T(primal(d))
     end
 end
 
-## Constants
-# These are methods defined on types. Methods on variables are in operators.jl
-# TODO: only return primal on methods on variable
-Base.zero(::Type{D})        where {P,T,D<:Dual{P,T}} = zero(P)
-Base.one(::Type{D})         where {P,T,D<:Dual{P,T}} = one(P)
-Base.oneunit(::Type{D})     where {P,T,D<:Dual{P,T}} = oneunit(P)
-Base.typemin(::Type{D})     where {P,T,D<:Dual{P,T}} = typemin(P)
-Base.typemax(::Type{D})     where {P,T,D<:Dual{P,T}} = typemax(P)
-Base.eps(::Type{D})         where {P,T,D<:Dual{P,T}} = eps(P)
-Base.floatmin(::Type{D})    where {P,T,D<:Dual{P,T}} = floatmin(P)
-Base.floatmax(::Type{D})    where {P,T,D<:Dual{P,T}} = floatmax(P)
-Base.maxintfloat(::Type{D}) where {P,T,D<:Dual{P,T}} = maxintfloat(P)
+##======================#
+# Named type promotions #
+#=======================#
 
-#! format: on
+for f in (:big, :widen, :float)
+    @eval Base.$f(::Type{T}) where {T<:AbstractTracer} = T
+    @eval Base.$f(::Type{D}) where {P,T,D<:Dual{P,T}} = $f(P) # only return primal type
+end
+
+##============================#
+# Constant functions on types #
+#=============================#
+
+# Methods on variables are in operators.jl 
+for f in
+    (:zero, :one, :oneunit, :typemin, :typemax, :eps, :floatmin, :floatmax, :maxintfloat)
+    @eval Base.$f(::Type{T}) where {T<:AbstractTracer} = myempty(T)
+    @eval Base.$f(::Type{D}) where {P,T,D<:Dual{P,T}} = $f(P) # only return primal
+end

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -45,11 +45,7 @@ end
 function test_type_conversion_functions(::Type{D}, f::Function) where {P,T,D<:Dual{P,T}}
     @testset "Primal type $P_IN" for P_IN in (Int, Float32, Irrational)
         P_OUT = f(P_IN)
-
-        # Note that this tests Dual{P_IN,T}, not Dual{P,T} 
-        D_IN = Dual{P_IN,T}
-        D_OUT = Dual{P_OUT,T}
-        @test f(D_IN) == D_OUT
+        @test f(Dual{P_IN,T}) == P_OUT  # NOTE: this tests Dual{P_IN,T}, not Dual{P,T} 
     end
 end
 


### PR DESCRIPTION
* `big`, `widen` and `float` now only return the promoted primal type when called on `Dual` 
* reorganize and shorten the code for type conversions
