### PR TITLE
Fix JET and DataInterpolations tests

### DIFF
--- a/src/overloads/ifelse_global.jl
+++ b/src/overloads/ifelse_global.jl
@@ -9,17 +9,19 @@
     end
 
     ## output union on scalar outputs
-    function output_union(tx::T, ty::T) where {T<:AbstractTracer}
+    function output_union(tx::T, ty::T) where {T<:GradientTracer}
         return T(output_union(pattern(tx), pattern(ty))) # return tracer
     end
     function output_union(px::P, py::P) where {P<:IndexSetGradientPattern}
         return P(union(gradient(px), gradient(py))) # return pattern
     end
 
-    function output_union(px::P, py::P) where {P<:AbstractHessianPattern}
-        return output_union(px, py, shared(P))
+    function output_union(tx::T, ty::T) where {T<:HessianTracer}
+        return T(output_union(pattern(tx), pattern(ty))) # return tracer
     end
-
+    function output_union(px::P, py::P) where {P<:AbstractHessianPattern}
+        return output_union(px, py, shared(P)) # return pattern
+    end
     function output_union(px::P, py::P, ::Shared) where {P<:AbstractHessianPattern}
         g_out = union(gradient(px), gradient(py))
         hx, hy = hessian(px), hessian(py)

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -180,7 +180,7 @@ function myempty(::Type{IndexSetGradientPattern{I,S}}) where {I,S}
     return IndexSetGradientPattern{I,S}(myempty(S))
 end
 function create_patterns(::Type{P}, xs, is) where {I,S,P<:IndexSetGradientPattern{I,S}}
-    sets = seed.(S, is)
+    sets = seed.(Ref(S), is)
     return P.(sets)
 end
 
@@ -274,7 +274,7 @@ function myempty(::Type{DictHessianPattern{I,S,D,SB}}) where {I,S,D,SB}
     return DictHessianPattern{I,S,D,SB}(myempty(S), myempty(D))
 end
 function create_patterns(::Type{P}, xs, is) where {I,S,D,SB,P<:DictHessianPattern{I,S,D,SB}}
-    gradients = seed.(S, is)
+    gradients = seed.(Ref(S), is)
     hessian = myempty(D)
     # Even if `NotShared`, sharing a single reference to `hessian` is allowed upon initialization, 
     # since mutation is prohibited when `isshared` is false.

--- a/test/ext/test_DataInterpolations.jl
+++ b/test/ext/test_DataInterpolations.jl
@@ -260,7 +260,7 @@ for N in (2, 5)
             InterpolationTest(
                 N, ConstantInterpolation(um, t); is_der1_zero=true, is_der2_zero=true
             ),
-            InterpolationTest(N, LinearInterpolation(um, t); is_der2_zero=true),
+            # InterpolationTest(N, LinearInterpolation(um, t); is_der2_zero=true), # TODO: include once https://github.com/SciML/DataInterpolations.jl/pull/335 is settled
             InterpolationTest(N, QuadraticInterpolation(um, t)),
             InterpolationTest(N, LagrangeInterpolation(um, t)),
             ## The following interpolations appear to not be supported on N dimensions as of DataInterpolations v6.2.0:


### PR DESCRIPTION
* address warnings from latest JET release 
* skip DataInterpolations test on `LinearInterpolations` until https://github.com/SciML/DataInterpolations.jl/pull/335#issuecomment-2386297056 is resolved.