### PR TITLE
Fix detector display by replacing `println` with `print`

### DIFF
--- a/src/adtypes_interface.jl
+++ b/src/adtypes_interface.jl
@@ -163,9 +163,9 @@ end
 for detector in (:TracerSparsityDetector, :TracerLocalSparsityDetector)
     @eval function Base.show(io::IO, d::$detector{TG,TH}) where {TG,TH}
         if TG == DEFAULT_GRADIENT_TRACER && TH == DEFAULT_HESSIAN_TRACER
-            println(io, $detector, "()")
+            print(io, $detector, "()")
         else
-            println(io, $detector, "{", TG, ",", TH, "}()")
+            print(io, $detector, "{", TG, ",", TH, "}()")
         end
         return nothing
     end


### PR DESCRIPTION
This fixes the following display:

```julia
julia> using ADTypes, SparseConnectivityTracer

julia> backend = AutoSparse(AutoForwardDiff(), sparsity_detector=TracerSparsityDetector())
AutoSparse(dense_ad=AutoForwardDiff(), sparsity_detector=TracerSparsityDetector()
)
```