### PR TITLE
Avoid overwriting methods when generating 2-to-1 overloads on arbitrary types 

### DIFF
--- a/src/overloads/ambiguities.jl
+++ b/src/overloads/ambiguities.jl
@@ -1,5 +1,5 @@
 ## Special overloads to avoid ambiguity errors
-eval(generate_code_2_to_1(:Base, ^, Integer))
-eval(generate_code_2_to_1(:Base, ^, Rational))
-eval(generate_code_2_to_1(:Base, ^, Irrational{:ℯ}))
-eval(generate_code_2_to_1(:Base, isless, AbstractFloat))
+eval(generate_code_2_to_1_typed(:Base, ^, Integer))
+eval(generate_code_2_to_1_typed(:Base, ^, Rational))
+eval(generate_code_2_to_1_typed(:Base, ^, Irrational{:ℯ}))
+eval(generate_code_2_to_1_typed(:Base, isless, AbstractFloat))

--- a/src/overloads/utils.jl
+++ b/src/overloads/utils.jl
@@ -28,21 +28,13 @@ for d in dims
 end
 
 # Overloads of 2-argument functions on arbitrary types
-function generate_code_2_to_1(M::Symbol, f, Z::Type)
-    expr_g = generate_code_gradient_2_to_1(M, f, Z)
-    expr_h = generate_code_hessian_2_to_1(M, f, Z)
+function generate_code_2_to_1_typed(M::Symbol, f, Z::Type)
+    expr_g = generate_code_gradient_2_to_1_typed(M, f, Z)
+    expr_h = generate_code_hessian_2_to_1_typed(M, f, Z)
     return Expr(:block, expr_g, expr_h)
 end
-function generate_code_2_to_1(M::Symbol, ops::Union{AbstractVector,Tuple}, Z::Type)
-    exprs = [generate_code_2_to_1(M, op, Z) for op in ops]
-    return Expr(:block, exprs...)
-end
-function generate_code_gradient_2_to_1(M::Symbol, ops::Union{AbstractVector,Tuple}, Z::Type)
-    exprs = [generate_code_gradient_2_to_1(M, op, Z) for op in ops]
-    return Expr(:block, exprs...)
-end
-function generate_code_hessian_2_to_1(M::Symbol, ops::Union{AbstractVector,Tuple}, Z::Type)
-    exprs = [generate_code_hessian_2_to_1(M, op, Z) for op in ops]
+function generate_code_2_to_1_typed(M::Symbol, ops::Union{AbstractVector,Tuple}, Z::Type)
+    exprs = [generate_code_2_to_1_typed(M, op, Z) for op in ops]
     return Expr(:block, exprs...)
 end
 


### PR DESCRIPTION
Fixes an oversight in #197 by separating overloads on arbitrary types from methods defined on tracers only, thus avoiding duplicate overwriting of existing methods.