### PR TITLE
Add compat for DataInterpolations v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ SparseConnectivityTracerSpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ADTypes = "1"
-DataInterpolations = "6.5"
+DataInterpolations = "6.5, 7"
 DocStringExtensions = "0.9"
 FillArrays = "1"
 LinearAlgebra = "<0.0.1, 1"


### PR DESCRIPTION
I didn't see a CompatHelper PR, but see the action failed last two times, not sure why: https://github.com/adrhill/SparseConnectivityTracer.jl/actions/workflows/CompatHelper.yml

The breaking changes relate to the extrapolation API, which doesn't affect this package.
https://github.com/SciML/DataInterpolations.jl/releases/tag/v7.0.0