### PR TITLE
Fix 3-arg `dot` ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SparseConnectivityTracer.jl
 
+## Version `v0.6.12`
+* ![Bugfix][badge-bugfix] Fix for method ambiguities resulting from the 3-argument `dot` methods introduced in `v0.6.11` ([#228])
+
 ## Version `v0.6.11`
 * ![Documentation][badge-docs] SCT has a new preprint! 🎉 
   Check it out on the arXiv: [*Sparser, Better, Faster, Stronger: Efficient Automatic Differentiation for Sparse Jacobians and Hessians*](https://arxiv.org/abs/2501.17737) ([#225])
@@ -97,6 +100,7 @@
 [badge-maintenance]: https://img.shields.io/badge/maintenance-gray.svg
 [badge-docs]: https://img.shields.io/badge/docs-orange.svg
 
+[#228]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/228
 [#226]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/226
 [#225]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/225
 [#223]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/223

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.6.11"
+version = "0.6.12-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/overloads/arrays.jl
+++ b/src/overloads/arrays.jl
@@ -104,11 +104,11 @@ for (Tx, TA, Ty) in Iterators.filter(
     nopiracy, # only keep tuples of types we own 
     Iterators.product(
         # Types for x
-        (Vector, Vector{<:AbstractTracer}, SubArray, SubArray{<:AbstractTracer}),
+        (Vector, Vector{<:AbstractTracer}, SubArray, SubArray{<:AbstractTracer,1}),
         # Types for A
         (Matrix, Matrix{<:AbstractTracer}),
         # Types for y
-        (Vector, Vector{<:AbstractTracer}, SubArray, SubArray{<:AbstractTracer}),
+        (Vector, Vector{<:AbstractTracer}, SubArray, SubArray{<:AbstractTracer,1}),
     ),
 )
     @eval LinearAlgebra.dot(x::$Tx, A::$TA, y::$Ty) = LinearAlgebra.dot(x, A * y)

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -1,6 +1,7 @@
 import SparseConnectivityTracer as SCT
 using SparseConnectivityTracer
-using SparseConnectivityTracer: GradientTracer, IndexSetGradientPattern, isemptytracer
+using SparseConnectivityTracer:
+    GradientTracer, IndexSetGradientPattern, isemptytracer, MissingPrimalError
 using Test
 
 using LinearAlgebra: Symmetric, Diagonal, diagind
@@ -24,8 +25,8 @@ function sameidx(s1::AbstractSet, s2::AbstractSet)
         return true
     else
         println("Index sets don't match:")
-        println(s1)
-        println(s2)
+        println("Detected:  ", s1)
+        println("Reference: ", s2)
         return false
     end
 end
@@ -411,6 +412,13 @@ end
     ty = [t3, t4]
     tA = [idx2tracer(9) idx2tracer(10); idx2tracer(11) idx2tracer(12)]
 
+    rx = rand(2)
+    ry = rand(2)
+    rA = rand(2, 2)
+    sx = sparse([1; 0])
+    sy = sparse([0; 1])
+    sA = sparse([1 0; 0 2])
+
     @testset "scalar-scalar" begin
         @test sameidx(dot(t1, t2), 1:4)
         @test sameidx(dot(t1, t3), [1, 3, 4, 5, 6])
@@ -419,8 +427,12 @@ end
     end
     @testset "vector-vector" begin
         @test sameidx(dot(tx, ty), 1:8)
-        @test sameidx(dot(tx, rand(2)), 1:4)
-        @test sameidx(dot(rand(2), ty), 5:8)
+        @test sameidx(dot(tx, ry), 1:4)
+        @test sameidx(dot(rx, ty), 5:8)
+        @testset "SparseArrays" begin
+            @test sameidx(dot(tx, sy), [2, 4])
+            @test sameidx(dot(sx, ty), 5:6)
+        end
         @test_throws DimensionMismatch dot(tx, rand(3))
         @test_throws DimensionMismatch dot(rand(3), ty)
 
@@ -430,13 +442,31 @@ end
         @test isemptytracer(out)
     end
     @testset "vector-Matrix-vector" begin
-        @test sameidx(dot(tx, rand(2, 2), rand(2)), 1:4)
-        @test sameidx(dot(tx, tA, rand(2)), vcat(1:4, 9:12))
-        @test sameidx(dot(tx, rand(2, 2), ty), 1:8)
+        @test sameidx(dot(tx, rA, ry), 1:4)
+        @test sameidx(dot(tx, tA, ry), vcat(1:4, 9:12))
+        @test sameidx(dot(tx, rA, ty), 1:8)
         @test sameidx(dot(tx, tA, ty), 1:12)
-        @test sameidx(dot(rand(2), tA, rand(2)), 9:12)
-        @test sameidx(dot(rand(2), tA, ty), 5:12)
-        @test sameidx(dot(rand(2), rand(2, 2), ty), 5:8)
+        @test sameidx(dot(rx, tA, ry), 9:12)
+        @test sameidx(dot(rx, tA, ty), 5:12)
+        @test sameidx(dot(rx, rA, ty), 5:8)
+
+        @testset "SparseArrays" begin
+            # Some tests are broken since there is no specialized support for SparseArrays.
+            # The purpose of these tests is to catch ambiguity errors.
+            @test sameidx(dot(tx, sA, ry), 1:4)
+            @test sameidx(dot(tx, rA, sy), 1:4)
+            @test_broken sameidx(dot(tx, sA, sy), [2, 4])  # overly conservative
+            @test sameidx(dot(tx, tA, sy), [1, 2, 3, 4, 10, 12])
+            @test sameidx(dot(tx, sA, ty), 1:8)
+            @test sameidx(dot(tx, tA, ty), 1:12)
+            @test_broken sameidx(dot(sx, tA, ry), [9, 10]) # overly conservative
+            @test sameidx(dot(rx, tA, sy), [10, 12])
+            @test_broken sameidx(dot(sx, tA, sy), 10) # overly conservative
+            @test_throws MissingPrimalError sameidx(dot(sx, tA, ty), 5:10)
+            @test_throws MissingPrimalError sameidx(dot(sx, rA, ty), 5:8)
+            @test sameidx(dot(rx, sA, ty), 5:8)
+            @test_broken sameidx(dot(sx, sA, ty), [5, 6]) # overly conservative
+        end
     end
 end
 

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -412,6 +412,11 @@ end
     ty = [t3, t4]
     tA = [idx2tracer(9) idx2tracer(10); idx2tracer(11) idx2tracer(12)]
 
+    # SubArray variants of tx and ty
+    B = [t1 t2; t3 t4]
+    subx = view(B, 1, :)
+    suby = view(B, 2, :)
+
     rx = rand(2)
     ry = rand(2)
     rA = rand(2, 2)
@@ -429,6 +434,15 @@ end
         @test sameidx(dot(tx, ty), 1:8)
         @test sameidx(dot(tx, ry), 1:4)
         @test sameidx(dot(rx, ty), 5:8)
+
+        @testset "SubArrays" begin
+            @test subx isa SubArray
+            @test suby isa SubArray
+            @test sameidx(dot(subx, suby), 1:8)
+            @test sameidx(dot(subx, ry), 1:4)
+            @test sameidx(dot(rx, suby), 5:8)
+        end
+
         @testset "SparseArrays" begin
             @test sameidx(dot(tx, sy), [2, 4])
             @test sameidx(dot(sx, ty), 5:6)
@@ -446,9 +460,21 @@ end
         @test sameidx(dot(tx, tA, ry), vcat(1:4, 9:12))
         @test sameidx(dot(tx, rA, ty), 1:8)
         @test sameidx(dot(tx, tA, ty), 1:12)
-        @test sameidx(dot(rx, tA, ry), 9:12)
         @test sameidx(dot(rx, tA, ty), 5:12)
         @test sameidx(dot(rx, rA, ty), 5:8)
+        @test sameidx(dot(rx, tA, ry), 9:12)
+
+        @testset "SubArrays" begin
+            @test subx isa SubArray
+            @test suby isa SubArray
+            @test sameidx(dot(subx, rA, ry), 1:4)
+            @test sameidx(dot(subx, tA, ry), vcat(1:4, 9:12))
+            @test sameidx(dot(subx, rA, suby), 1:8)
+            @test sameidx(dot(subx, tA, suby), 1:12)
+            @test sameidx(dot(rx, tA, suby), 5:12)
+            @test sameidx(dot(rx, rA, suby), 5:8)
+            @test sameidx(dot(rx, tA, ry), 9:12)
+        end
 
         @testset "SparseArrays" begin
             # Some tests are broken since there is no specialized support for SparseArrays.

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -453,19 +453,19 @@ end
         @testset "SparseArrays" begin
             # Some tests are broken since there is no specialized support for SparseArrays.
             # The purpose of these tests is to catch ambiguity errors.
-            @test sameidx(dot(tx, sA, ry), 1:4)
-            @test sameidx(dot(tx, rA, sy), 1:4)
-            @test_broken sameidx(dot(tx, sA, sy), [2, 4])  # overly conservative
-            @test sameidx(dot(tx, tA, sy), [1, 2, 3, 4, 10, 12])
-            @test sameidx(dot(tx, sA, ty), 1:8)
-            @test sameidx(dot(tx, tA, ty), 1:12)
-            @test_broken sameidx(dot(sx, tA, ry), [9, 10]) # overly conservative
-            @test sameidx(dot(rx, tA, sy), [10, 12])
-            @test_broken sameidx(dot(sx, tA, sy), 10) # overly conservative
-            @test_throws MissingPrimalError sameidx(dot(sx, tA, ty), 5:10)
-            @test_throws MissingPrimalError sameidx(dot(sx, rA, ty), 5:8)
-            @test sameidx(dot(rx, sA, ty), 5:8)
-            @test_broken sameidx(dot(sx, sA, ty), [5, 6]) # overly conservative
+            @test_nowarn dot(tx, sA, ry)
+            @test_nowarn dot(tx, rA, sy)
+            @test_nowarn dot(tx, sA, sy)
+            @test_nowarn dot(tx, tA, sy)
+            @test_nowarn dot(tx, sA, ty)
+            @test_nowarn dot(tx, tA, ty)
+            @test_nowarn dot(sx, tA, ry)
+            @test_nowarn dot(rx, tA, sy)
+            @test_nowarn dot(sx, tA, sy)
+            @test_throws MissingPrimalError dot(sx, tA, ty)
+            @test_throws MissingPrimalError dot(sx, rA, ty)
+            @test_nowarn dot(rx, sA, ty)
+            @test_nowarn dot(sx, sA, ty)
         end
     end
 end


### PR DESCRIPTION
Hotfix closing #227 by only overloading `dot` on concrete array types. These currently only include `Vector`, `Matrix` and `Subarray` for #224.

In the long run, a more general solution should be found, e.g. using CasetteOverlay.