### PR TITLE
Add stable API for allocation of buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SparseConnectivityTracer.jl
 
 ## Version `v0.6.14`
-* ![Feature][badge-feature] Add stable API for allocation of buffers via `jacobian_buffer` and `hessian_buffer`
+* ![Feature][badge-feature] Add stable API for allocation of buffers via `jacobian_buffer` and `hessian_buffer` ([#232])
 
 ## Version `v0.6.13`
 * ![Bugfix][badge-bugfix] Return `Dual` on `zero` and friends ([#231])
@@ -106,6 +106,7 @@
 [badge-maintenance]: https://img.shields.io/badge/maintenance-gray.svg
 [badge-docs]: https://img.shields.io/badge/docs-orange.svg
 
+[#232]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/232
 [#231]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/231
 [#228]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/228
 [#226]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/226

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SparseConnectivityTracer.jl
 
+## Version `v0.6.14`
+* ![Feature][badge-feature] Add stable API for allocation of buffers via `jacobian_buffer` and `hessian_buffer`
+
 ## Version `v0.6.13`
 * ![Bugfix][badge-bugfix] Return `Dual` on `zero` and friends ([#231])
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.6.13"
+version = "0.6.14-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -24,3 +24,10 @@ To compute **local** sparsity patterns of `f(x)` at a specific input `x`, use
 TracerLocalSparsityDetector
 ```
 
+## Memory allocation
+
+For developers requiring the allocation of output buffers that support our tracers, we additionally provide
+```@docs
+jacobian_buffer
+hessian_buffer
+```

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -39,4 +39,6 @@ export TracerLocalSparsityDetector
 # Reexport ADTypes interface
 export jacobian_sparsity, hessian_sparsity
 
+export jacobian_buffer, hessian_buffer
+
 end # module

--- a/src/adtypes_interface.jl
+++ b/src/adtypes_interface.jl
@@ -189,7 +189,7 @@ end
 """
     hessian_buffer(x, detector)
 
-Allocate a buffer similiar to `x` with the required tracer type for Jacobian sparsity detection.
+Allocate a buffer similiar to `x` with the required tracer type for Hessian sparsity detection.
 Thin wrapper around `similar` that doesn't expose internal types.
 """
 hessian_buffer(x, ::TracerSparsityDetector{TG,TH}) where {TG,TH} = similar(x, TH)

--- a/src/adtypes_interface.jl
+++ b/src/adtypes_interface.jl
@@ -170,3 +170,32 @@ for detector in (:TracerSparsityDetector, :TracerLocalSparsityDetector)
         return nothing
     end
 end
+
+## Stable API to allow packages like DI to allocate caches of tracers
+"""
+    jacobian_buffer(x, detector)
+
+Allocate a buffer similiar to `x` with the required tracer type for Jacobian sparsity detection.
+Thin wrapper around `similar` that doesn't expose internal types.
+"""
+jacobian_buffer(x, ::TracerSparsityDetector{TG}) where {TG} = similar(x, TG)
+
+function jacobian_buffer(x, ::TracerLocalSparsityDetector{TG}) where {TG}
+    P = eltype(x)
+    D = Dual{P,TG}
+    return similar(x, D)
+end
+
+"""
+    hessian_buffer(x, detector)
+
+Allocate a buffer similiar to `x` with the required tracer type for Jacobian sparsity detection.
+Thin wrapper around `similar` that doesn't expose internal types.
+"""
+hessian_buffer(x, ::TracerSparsityDetector{TG,TH}) where {TG,TH} = similar(x, TH)
+
+function hessian_buffer(x, ::TracerLocalSparsityDetector{TG,TH}) where {TG,TH}
+    P = eltype(x)
+    D = Dual{P,TH}
+    return similar(x, D)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,9 @@ GROUP = get(ENV, "JULIA_SCT_TEST_GROUP", "Core")
             @testset "HessianTracer" begin
                 include("test_hessian.jl")
             end
+            @testset "Buffer allocation" begin
+                include("test_buffers.jl")
+            end
             @testset "Array overloads" begin
                 include("test_arrays.jl")
             end

--- a/test/test_buffers.jl
+++ b/test/test_buffers.jl
@@ -1,0 +1,48 @@
+using SparseConnectivityTracer
+using SparseConnectivityTracer: GradientTracer, HessianTracer, Dual
+using Test
+
+# Load definitions of GRADIENT_TRACERS, GRADIENT_PATTERNS, HESSIAN_TRACERS and HESSIAN_PATTERNS
+include("tracers_definitions.jl")
+
+@testset "Jacobian" begin
+    P = Float32
+    x = rand(P, 3, 2)
+    @testset "$GP" for GP in GRADIENT_PATTERNS
+        T = GradientTracer{GP}
+        D = Dual{P,T}
+        @testset "Global" begin
+            detector = TracerSparsityDetector(; gradient_tracer_type=T)
+            buff = jacobian_buffer(x, detector)
+            @test size(buff) == (3, 2)
+            @test eltype(buff) == T
+        end
+        @testset "Local" begin
+            detector = TracerLocalSparsityDetector(; gradient_tracer_type=T)
+            buff = jacobian_buffer(x, detector)
+            @test size(buff) == (3, 2)
+            @test eltype(buff) == D
+        end
+    end
+end
+
+@testset "Hessian" begin
+    P = Float32
+    x = rand(P, 3, 2)
+    @testset "$HP" for HP in HESSIAN_PATTERNS
+        T = HessianTracer{HP}
+        D = Dual{P,T}
+        @testset "Global" begin
+            detector = TracerSparsityDetector(; hessian_tracer_type=T)
+            buff = hessian_buffer(x, detector)
+            @test size(buff) == (3, 2)
+            @test eltype(buff) == T
+        end
+        @testset "Local" begin
+            detector = TracerLocalSparsityDetector(; hessian_tracer_type=T)
+            buff = hessian_buffer(x, detector)
+            @test size(buff) == (3, 2)
+            @test eltype(buff) == D
+        end
+    end
+end


### PR DESCRIPTION
For use in external packages like DI (see https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/737).

I'm open to a name change for the two functions.