### PR TITLE
Add stable API for tracer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SparseConnectivityTracer.jl
 
+## Version `v0.6.15`
+* ![Feature][badge-feature] Add stable API for tracer type via `jacobian_tracer_type` and `hessian_tracer_type` ([#233])
+
 ## Version `v0.6.14`
 * ![Feature][badge-feature] Add stable API for allocation of buffers via `jacobian_buffer` and `hessian_buffer` ([#232])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SparseConnectivityTracer.jl
 
 ## Version `v0.6.15`
-* ![Feature][badge-feature] Add stable API for tracer type via `jacobian_tracer_type` and `hessian_tracer_type` ([#233])
+* ![Feature][badge-feature] Add stable API for tracer type via `jacobian_eltype` and `hessian_eltype` ([#233])
 
 ## Version `v0.6.14`
 * ![Feature][badge-feature] Add stable API for allocation of buffers via `jacobian_buffer` and `hessian_buffer` ([#232])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 [badge-maintenance]: https://img.shields.io/badge/maintenance-gray.svg
 [badge-docs]: https://img.shields.io/badge/docs-orange.svg
 
+[#233]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/233
 [#232]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/232
 [#231]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/231
 [#228]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/228

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -28,8 +28,8 @@ TracerLocalSparsityDetector
 
 For developers requiring the allocation of output buffers that support our tracers, we additionally provide
 ```@docs
-jacobian_tracer_type
-hessian_tracer_type
+jacobian_eltype
+hessian_eltype
 jacobian_buffer
 hessian_buffer
 ```

--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -28,6 +28,8 @@ TracerLocalSparsityDetector
 
 For developers requiring the allocation of output buffers that support our tracers, we additionally provide
 ```@docs
+jacobian_tracer_type
+hessian_tracer_type
 jacobian_buffer
 hessian_buffer
 ```

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -39,6 +39,7 @@ export TracerLocalSparsityDetector
 # Reexport ADTypes interface
 export jacobian_sparsity, hessian_sparsity
 
+export jacobian_tracer_type, hessian_tracer_type
 export jacobian_buffer, hessian_buffer
 
 end # module

--- a/src/SparseConnectivityTracer.jl
+++ b/src/SparseConnectivityTracer.jl
@@ -39,7 +39,7 @@ export TracerLocalSparsityDetector
 # Reexport ADTypes interface
 export jacobian_sparsity, hessian_sparsity
 
-export jacobian_tracer_type, hessian_tracer_type
+export jacobian_eltype, hessian_eltype
 export jacobian_buffer, hessian_buffer
 
 end # module

--- a/src/adtypes_interface.jl
+++ b/src/adtypes_interface.jl
@@ -178,16 +178,24 @@ end
 
 Return the tracer type used for Jacobian sparsity detection.
 """
-jacobian_tracer_type(x, ::TracerSparsityDetector{TG}) where {TG} = TG
-jacobian_tracer_type(x, ::TracerLocalSparsityDetector{TG}) where {TG} = Dual{eltype(x),TG}
+jacobian_tracer_type(x::AbstractArray{<:Real}, ::TracerSparsityDetector{TG}) where {TG} = TG
+function jacobian_tracer_type(
+    x::AbstractArray{<:Real}, ::TracerLocalSparsityDetector{TG}
+) where {TG}
+    return Dual{eltype(x),TG}
+end
 
 """
     hessian_tracer_type(x, detector)
 
 Return the tracer type used for Hessian sparsity detection.
 """
-hessian_tracer_type(x, ::TracerSparsityDetector{TG,TH}) where {TG,TH} = TH
-function hessian_tracer_type(x, ::TracerLocalSparsityDetector{TG,TH}) where {TG,TH}
+hessian_tracer_type(
+    x::AbstractArray{<:Real}, ::TracerSparsityDetector{TG,TH}
+) where {TG,TH} = TH
+function hessian_tracer_type(
+    x::AbstractArray{<:Real}, ::TracerLocalSparsityDetector{TG,TH}
+) where {TG,TH}
     return Dual{eltype(x),TH}
 end
 

--- a/src/adtypes_interface.jl
+++ b/src/adtypes_interface.jl
@@ -174,28 +174,22 @@ end
 ## Stable API to allow packages like DI to allocate caches of tracers
 
 """
-    jacobian_tracer_type(x, detector)
+    jacobian_eltype(x, detector)
 
-Return the tracer type used for Jacobian sparsity detection.
+Act like `eltype(x)` but return the matching number type used inside Jacobian sparsity detection.
 """
-jacobian_tracer_type(x::AbstractArray{<:Real}, ::TracerSparsityDetector{TG}) where {TG} = TG
-function jacobian_tracer_type(
-    x::AbstractArray{<:Real}, ::TracerLocalSparsityDetector{TG}
-) where {TG}
+jacobian_eltype(x, ::TracerSparsityDetector{TG}) where {TG} = TG
+function jacobian_eltype(x, ::TracerLocalSparsityDetector{TG}) where {TG}
     return Dual{eltype(x),TG}
 end
 
 """
-    hessian_tracer_type(x, detector)
+    hessian_eltype(x, detector)
 
-Return the tracer type used for Hessian sparsity detection.
+Act like `eltype(x)` but return the matching number type used inside Hessian sparsity detection.
 """
-hessian_tracer_type(
-    x::AbstractArray{<:Real}, ::TracerSparsityDetector{TG,TH}
-) where {TG,TH} = TH
-function hessian_tracer_type(
-    x::AbstractArray{<:Real}, ::TracerLocalSparsityDetector{TG,TH}
-) where {TG,TH}
+hessian_eltype(x, ::TracerSparsityDetector{TG,TH}) where {TG,TH} = TH
+function hessian_eltype(x, ::TracerLocalSparsityDetector{TG,TH}) where {TG,TH}
     return Dual{eltype(x),TH}
 end
 
@@ -208,7 +202,7 @@ Thin wrapper around `similar` that doesn't expose internal types.
 function jacobian_buffer(
     x, detector::Union{TracerSparsityDetector,TracerLocalSparsityDetector}
 )
-    return similar(x, jacobian_tracer_type(x, detector))
+    return similar(x, jacobian_eltype(x, detector))
 end
 
 """
@@ -220,5 +214,5 @@ Thin wrapper around `similar` that doesn't expose internal types.
 function hessian_buffer(
     x, detector::Union{TracerSparsityDetector,TracerLocalSparsityDetector}
 )
-    return similar(x, hessian_tracer_type(x, detector))
+    return similar(x, hessian_eltype(x, detector))
 end


### PR DESCRIPTION
This is needed in DI for caches that are more complex than arrays: I need access to the element type and not just to a `similar` variant because I write my own recursive `similar` variant.

No need for additional testing since I use the new functions functions inside `jacobian_buffer` and `hessian_buffer`.