### PR TITLE
DataInterpolations v8 compatiblity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ SparseConnectivityTracerSpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ADTypes = "1"
-DataInterpolations = "6.5, 7"
+DataInterpolations = "8.1"
 DocStringExtensions = "0.9"
 FillArrays = "1"
 LinearAlgebra = "<0.0.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ SparseConnectivityTracerSpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ADTypes = "1"
-DataInterpolations = "8.1"
+DataInterpolations = "8.0.1"
 DocStringExtensions = "0.9"
 FillArrays = "1"
 LinearAlgebra = "<0.0.1, 1"

--- a/ext/SparseConnectivityTracerDataInterpolationsExt.jl
+++ b/ext/SparseConnectivityTracerDataInterpolationsExt.jl
@@ -6,8 +6,8 @@ using SparseConnectivityTracer: AbstractTracer, Dual, primal, tracer
 using SparseConnectivityTracer: GradientTracer, gradient_tracer_1_to_1
 using SparseConnectivityTracer: HessianTracer, hessian_tracer_1_to_1
 using FillArrays: Fill # from FillArrays.jl
-import DataInterpolations: AbstractInterpolation
-import DataInterpolations:
+using DataInterpolations:
+    AbstractInterpolation,
     LinearInterpolation,
     QuadraticInterpolation,
     LagrangeInterpolation,
@@ -19,48 +19,55 @@ import DataInterpolations:
     BSplineApprox,
     CubicHermiteSpline,
     # PCHIPInterpolation,
-    QuinticHermiteSpline
+    QuinticHermiteSpline,
+    output_size
 
 #===========#
 # Utilities #
 #===========#
 
+# Limit support to `u` begin an AbstractVector{<:Number} or AbstractMatrix{<:Number},
+# to avoid any cases where the output size is dependent on the input value.
+# https://github.com/adrhill/SparseConnectivityTracer.jl/pull/234#discussion_r2031038566
+
 function _sct_interpolate(
-    ::AbstractInterpolation{T,N},
-    uType::Type{V},
+    ::AbstractInterpolation,
+    uType::Type{<:AbstractVector{<:Number}},
     t::GradientTracer,
     is_der_1_zero,
     is_der_2_zero,
-) where {T,N,V<:AbstractVector}
+)
     return gradient_tracer_1_to_1(t, is_der_1_zero)
 end
 function _sct_interpolate(
-    ::AbstractInterpolation{T,N},
-    uType::Type{V},
+    ::AbstractInterpolation,
+    uType::Type{<:AbstractVector{<:Number}},
     t::HessianTracer,
     is_der_1_zero,
     is_der_2_zero,
-) where {T,N,V<:AbstractVector}
+)
     return hessian_tracer_1_to_1(t, is_der_1_zero, is_der_2_zero)
 end
 function _sct_interpolate(
-    ::AbstractInterpolation{T,N},
-    uType::Type{M},
+    interp::AbstractInterpolation,
+    uType::Type{<:AbstractMatrix{<:Number}},
     t::GradientTracer,
     is_der_1_zero,
     is_der_2_zero,
-) where {T,N,M<:AbstractMatrix}
+)
     t = gradient_tracer_1_to_1(t, is_der_1_zero)
+    N = only(output_size(interp))
     return Fill(t, N)
 end
 function _sct_interpolate(
-    ::AbstractInterpolation{T,N},
-    uType::Type{M},
+    interp::AbstractInterpolation,
+    uType::Type{<:AbstractMatrix{<:Number}},
     t::HessianTracer,
     is_der_1_zero,
     is_der_2_zero,
-) where {T,N,M<:AbstractMatrix}
+)
     t = hessian_tracer_1_to_1(t, is_der_1_zero, is_der_2_zero)
+    N = only(output_size(interp))
     return Fill(t, N)
 end
 
@@ -84,7 +91,7 @@ for (I, is_der1_zero, is_der2_zero) in (
     (:CubicHermiteSpline, false, false),
     (:QuinticHermiteSpline, false, false),
 )
-    @eval function (interp::$(I){uType})(t::AbstractTracer) where {uType}
+    @eval function (interp::$(I){uType})(t::AbstractTracer) where {uType<:AbstractArray{<:Number}}
         return _sct_interpolate(interp, uType, t, $is_der1_zero, $is_der2_zero)
     end
 end

--- a/ext/SparseConnectivityTracerDataInterpolationsExt.jl
+++ b/ext/SparseConnectivityTracerDataInterpolationsExt.jl
@@ -91,7 +91,9 @@ for (I, is_der1_zero, is_der2_zero) in (
     (:CubicHermiteSpline, false, false),
     (:QuinticHermiteSpline, false, false),
 )
-    @eval function (interp::$(I){uType})(t::AbstractTracer) where {uType<:AbstractArray{<:Number}}
+    @eval function (interp::$(I){uType})(
+        t::AbstractTracer
+    ) where {uType<:AbstractArray{<:Number}}
         return _sct_interpolate(interp, uType, t, $is_der1_zero, $is_der2_zero)
     end
 end

--- a/test/ext/test_DataInterpolations.jl
+++ b/test/ext/test_DataInterpolations.jl
@@ -35,8 +35,10 @@ struct InterpolationTest{N,I<:AbstractInterpolation} # N = output dim. of interp
 end
 function InterpolationTest(
     interp::I; is_der1_zero=false, is_der2_zero=false
-) where {T,N,I<:AbstractInterpolation{T,N}}
-    return InterpolationTest{only(N),I}(interp, is_der1_zero, is_der2_zero)
+) where {T,I<:AbstractInterpolation{T}}
+    sz = output_size(interp)
+    N = isempty(sz) ? 1 : only(sz)
+    return InterpolationTest{N,I}(interp, is_der1_zero, is_der2_zero)
 end
 testname(t::InterpolationTest{N}) where {N} = "$N-dim $(typeof(t.interp))"
 


### PR DESCRIPTION
The breaking change in this release is https://github.com/SciML/DataInterpolations.jl/pull/396.

In that PR SparseConnectivityTracer was mentioned as one of the few users of the output dimension type parameter, and the [`output_dim`](https://github.com/SciML/DataInterpolations.jl/pull/396/files#diff-ec9d52d592efcfac03054654f1ddb93fa39df2988f98c3fd169c7f6c40c0ad1b) function was added to support SCT. In this PR I don't use that yet since it is different from what was used for the type parameter before, [`get_output_dim`](https://github.com/SciML/DataInterpolations.jl/pull/396/files#diff-fa2846ef87a68f71065b886fe1d1957d611d94d3478d183e44a6e6c88dbf6739). So I moved that function into the extension.

This works, though perhaps it would be better to use `output_dim` instead and simplify the code where possible. I got a bit stuck with that though since before scalar output got N = 1, now that is 0, leading to dimension mismatches. So for now I left it as a TODO in the code.

cc @SouthEndMusic