### PR TITLE
Stop tracing through multiplication by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SparseConnectivityTracer.jl
 
+## Version `v0.6.18`
+* ![Enhancement][badge-enhancement] Stop tracing through multiplication by zero ([#243])
+
 ## Version `v0.6.17`
 * ![Enhancement][badge-enhancement] Performance optimization in pattern creation ([#239])
 
@@ -115,6 +118,7 @@
 [badge-maintenance]: https://img.shields.io/badge/maintenance-gray.svg
 [badge-docs]: https://img.shields.io/badge/docs-orange.svg
 
+[#243]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/243
 [#239]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/239
 [#236]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/236
 [#233]: https://github.com/adrhill/SparseConnectivityTracer.jl/pull/233

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.6.19"
+version = "0.6.19-DEV"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseConnectivityTracer"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "0.6.17"
+version = "0.6.18"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/overloads/arrays.jl
+++ b/src/overloads/arrays.jl
@@ -115,36 +115,6 @@ for (Tx, TA, Ty) in Iterators.filter(
 end
 
 ## Multiplication
-function Base.:*(A::Matrix{T}, B::Matrix) where {T<:GradientTracer}
-    if size(A, 2) != size(B, 1)
-        throw(DimensionMismatch("arguments must have compatible dimensions"))
-    end
-    t = map(first_order_or, eachrow(A))
-    return repeat(t, 1, size(B, 2))
-end
-function Base.:*(A::Matrix{T}, B::Vector) where {T<:GradientTracer}
-    if size(A, 2) != length(B)
-        throw(DimensionMismatch("arguments must have compatible dimensions"))
-    end
-    t = map(first_order_or, eachrow(A))
-    return t
-end
-
-function Base.:*(A::Matrix, B::Matrix{T}) where {T<:GradientTracer}
-    if size(A, 2) != size(B, 1)
-        throw(DimensionMismatch("arguments must have compatible dimensions"))
-    end
-    t = map(first_order_or, eachcol(B))
-    return repeat(transpose(t), size(A, 1), 1)
-end
-function Base.:*(A::Matrix, B::Vector{T}) where {T<:GradientTracer}
-    if size(A, 2) != length(B)
-        throw(DimensionMismatch("arguments must have compatible dimensions"))
-    end
-    t = first_order_or(B)
-    return fill(t, size(A, 1))
-end
-
 function Base.:*(A::Matrix{T}, B::Matrix{T}) where {T<:GradientTracer}
     if size(A, 2) != size(B, 1)
         throw(DimensionMismatch("arguments must have compatible dimensions"))

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -147,13 +147,13 @@ end
 function generate_code_gradient_2_to_1_typed(
     M::Symbol,   # Symbol indicating Module of f, usually `:Base`
     f::Function, # function to overload
-    Z::Type,     # external non-tracer-type to overload on 
+    Z::Type,     # external non-tracer-type to overload on
 )
     fname = nameof(f)
     is_der1_arg1_zero_g = is_der1_arg1_zero_global(f)
     is_der1_arg2_zero_g = is_der1_arg2_zero_global(f)
 
-    if f === Base.:*  # special case
+    if f === Base.:*  # TODO: generalize to other cases (#244)
         expr_tracer_type = quote
             function $M.$fname(tx::$SCT.GradientTracer, y::$Z)
                 is_der1_arg1_zero_g_tweaked = iszero(y)

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -31,7 +31,7 @@ function hessian_tracer_1_to_1_inner(
         h
     elseif is_der1_zero && !is_der2_zero # 𝟙[∇²γ] = 𝟙[∇α] ∨ 𝟙[∇α]ᵀ
         # TODO: this branch of the code currently isn't tested.
-        # Covering it would require a scalar 1-to-1 function with local overloads, 
+        # Covering it would require a scalar 1-to-1 function with local overloads,
         # such that ∂f/∂x == 0 and ∂²f/∂x² != 0.
         union_product!(myempty(h), g, g)
     else # !is_der1_zero && !is_der2_zero,  𝟙[∇²γ] = 𝟙[∇²α] ∨ (𝟙[∇α] ∨ 𝟙[∇α]ᵀ)
@@ -178,7 +178,7 @@ end
 function generate_code_hessian_2_to_1(
     M::Symbol,    # Symbol indicating Module of f, usually `:Base`
     f::Function,  # function to overload
-    Z::Type=Real, # external non-tracer-type to overload on 
+    Z::Type=Real, # external non-tracer-type to overload on
 )
     fname = nameof(f)
     is_der1_arg1_zero_g = is_der1_arg1_zero_global(f)
@@ -253,7 +253,7 @@ end
 function generate_code_hessian_2_to_1_typed(
     M::Symbol,   # Symbol indicating Module of f, usually `:Base`
     f::Function, # function to overload
-    Z::Type,     # external non-tracer-type to overload on 
+    Z::Type,     # external non-tracer-type to overload on
 )
     fname = nameof(f)
     is_der1_arg1_zero_g = is_der1_arg1_zero_global(f)
@@ -261,7 +261,7 @@ function generate_code_hessian_2_to_1_typed(
     is_der1_arg2_zero_g = is_der1_arg2_zero_global(f)
     is_der2_arg2_zero_g = is_der2_arg2_zero_global(f)
 
-    if f === Base.:*  # special case
+    if f === Base.:*  # TODO: generalize to other cases (#244)
         expr_tracer_type = quote
             function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
                 is_der1_arg1_zero_g_tweaked = iszero(y)

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -261,18 +261,37 @@ function generate_code_hessian_2_to_1_typed(
     is_der1_arg2_zero_g = is_der1_arg2_zero_global(f)
     is_der2_arg2_zero_g = is_der2_arg2_zero_global(f)
 
-    expr_tracer_type = quote
-        function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
-            return @noinline $SCT.hessian_tracer_1_to_1(
-                tx, $is_der1_arg1_zero_g, $is_der2_arg1_zero_g
-            )
+    if f === Base.:*  # special case
+        expr_tracer_type = quote
+            function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
+                is_der1_arg1_zero_g_tweaked = iszero(y)
+                return @noinline $SCT.hessian_tracer_1_to_1(
+                    tx, is_der1_arg1_zero_g_tweaked, true
+                )
+            end
         end
-    end
-    expr_type_tracer = quote
-        function $M.$fname(x::$Z, ty::$SCT.HessianTracer)
-            return @noinline $SCT.hessian_tracer_1_to_1(
-                ty, $is_der1_arg2_zero_g, $is_der2_arg2_zero_g
-            )
+        expr_type_tracer = quote
+            function $M.$fname(x::$Z, ty::$SCT.HessianTracer)
+                is_der1_arg2_zero_g_tweaked = iszero(x)
+                return @noinline $SCT.hessian_tracer_1_to_1(
+                    ty, is_der1_arg2_zero_g_tweaked, true
+                )
+            end
+        end
+    else
+        expr_tracer_type = quote
+            function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
+                return @noinline $SCT.hessian_tracer_1_to_1(
+                    tx, $is_der1_arg1_zero_g, $is_der2_arg1_zero_g
+                )
+            end
+        end
+        expr_type_tracer = quote
+            function $M.$fname(x::$Z, ty::$SCT.HessianTracer)
+                return @noinline $SCT.hessian_tracer_1_to_1(
+                    ty, $is_der1_arg2_zero_g, $is_der2_arg2_zero_g
+                )
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ Pkg.develop(;
 
 using SparseConnectivityTracer
 using Documenter: Documenter, DocMeta
-using Test
+using Test, LinearAlgebra
 
 DocMeta.setdocmeta!(
     SparseConnectivityTracer,

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -170,8 +170,10 @@ T = GradientTracer{P}
         end
 
         @testset "Multiplication by zero" begin
-            f(x) = Matrix(I(length(x))) * x
-            @test J(f, ones(10)) == I(10)
+            f1(x) = [0 * x[1]]
+            @test J(f1, [1.0]) == [0;;]
+            f2(x) = Matrix(I(length(x))) * x
+            @test J(f2, ones(10)) == I(10)
         end
 
         yield()

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -169,6 +169,11 @@ T = GradientTracer{P}
             ]
         end
 
+        @testset "Multiplication by zero" begin
+            f(x) = Matrix(I(length(x))) * x
+            @test J(f, ones(10)) == I(10)
+        end
+
         yield()
     end
 end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -3,7 +3,7 @@ using SparseConnectivityTracer: GradientTracer, Dual, MissingPrimalError
 using Test
 
 using Random: rand, GLOBAL_RNG
-using LinearAlgebra: det, dot, logdet
+using LinearAlgebra: I, det, dot, logdet
 
 # Load definitions of GRADIENT_TRACERS, GRADIENT_PATTERNS, HESSIAN_TRACERS and HESSIAN_PATTERNS
 include("tracers_definitions.jl")

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -1,6 +1,7 @@
 using SparseConnectivityTracer
 using SparseConnectivityTracer: Dual, HessianTracer, MissingPrimalError
 using SparseConnectivityTracer: create_tracers, pattern, shared
+using LinearAlgebra: I, dot
 using Test
 using Random: rand, GLOBAL_RNG
 
@@ -269,10 +270,12 @@ D = Dual{Int,T}
         end
 
         @testset "Multiplication by zero" begin
-            f1(x) = 0 * x[1]^2
-            @test H(f1, [1.0]) == [0;;]
-            f2(x) = dot(x, Matrix(I(length(x))), x)
-            @test H(f2, ones(10)) == I(10)
+            if !Bool(shared(T))
+                f1(x) = 0 * x[1]^2
+                @test H(f1, [1.0]) == [0;;]
+                f2(x) = dot(x, Matrix(I(length(x))), x)
+                @test H(f2, ones(10)) == I(10)
+            end
         end
 
         yield()

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -267,6 +267,12 @@ D = Dual{Int,T}
             # TypeError: non-boolean (SparseConnectivityTracer.GradientTracer{BitSet}) used in boolean context
             @test_throws TypeError H(x -> x[1] > x[2] ? x[1]^x[2] : x[3] * x[4], rand(4))
         end
+
+        @testset "Multiplication by zero" begin
+            f(x) = dot(x, Matrix(I(length(x))), x)
+            @test H(f, ones(10)) == I(10)
+        end
+
         yield()
     end
 end

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -269,8 +269,10 @@ D = Dual{Int,T}
         end
 
         @testset "Multiplication by zero" begin
-            f(x) = dot(x, Matrix(I(length(x))), x)
-            @test H(f, ones(10)) == I(10)
+            f1(x) = [0 * x[1]^2]
+            @test H(f1, [1.0]) == [0;;]
+            f2(x) = dot(x, Matrix(I(length(x))), x)
+            @test H(f2, ones(10)) == I(10)
         end
 
         yield()

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -269,7 +269,7 @@ D = Dual{Int,T}
         end
 
         @testset "Multiplication by zero" begin
-            f1(x) = [0 * x[1]^2]
+            f1(x) = 0 * x[1]^2
             @test H(f1, [1.0]) == [0;;]
             f2(x) = dot(x, Matrix(I(length(x))), x)
             @test H(f2, ones(10)) == I(10)


### PR DESCRIPTION
- Add a special case for `Base.:*` inside `generate_code_gradient_2_to_1_typed` and `generate_code_hessian_2_to_1_typed`, which takes into account whether the other (non-traced) argument is zero
- Add tests