### PR TITLE
Remove global overloads based on auxiliary values, document design principles

### DIFF
--- a/docs/src/internals/adding_overloads.md
+++ b/docs/src/internals/adding_overloads.md
@@ -197,9 +197,11 @@ If such an overload is necessary (e.g. for array inputs), it should follow the f
 - Tracers must error instead of entering branches in user code. 
   This requires that overloads return tracers instead of `Bool` (or numbers), 
   as the former are designed to error in comparisons.
-- Overloads must ignore auxiliary, non-tracer values. 
-  While SCT can't guarantee conserservative sparsity patterns on stateful user code (e.g. due to auxiliary inputs entering branches), 
-  we try to support as much stateful code as possible. As such, we can't assume auxiliary values to stay constant.
-  *(While not set in stone, changing this rule in future would require a breaking release.)*
+- Overloads must ignore values of non-tracer inputs. 
+  While SCT can't guarantee conserservative sparsity patterns on stateful user code 
+  (e.g. due to stateful non-tracer values entering branches, see `f(x) = randn() > 0.5 ? x : 0`), 
+  we try to support as much of it as possible. 
+  Overloads therefore can't assume non-tracer values to stay constant and instead need to return conservative patterns.
+  *(While not set in stone, changing this rule in the future would require a breaking release.)*
 - Sparsity should be prioritized over performance. We assume global sparsity detection can be amortized.
 - `MethodError`s due to missing overloads can be avoided by returning a very conservative sparsity pattern.

--- a/docs/src/internals/adding_overloads.md
+++ b/docs/src/internals/adding_overloads.md
@@ -1,4 +1,4 @@
-# Adding Overloads
+# [Adding Overloads](@id adding-overloads)
 
 !!! danger "Internals may change"
     The developer documentation might refer to internals which can change without warning in a future release of SparseConnectivityTracer.
@@ -197,11 +197,7 @@ If such an overload is necessary (e.g. for array inputs), it should follow the f
 - Tracers must error instead of entering branches in user code. 
   This requires that overloaded functions return tracers instead of `Bool` (or numbers), 
   as the former are designed to error in comparisons.
-- Overloads must ignore scalar values of non-tracer inputs. 
-  While SCT can't guarantee conserservative sparsity patterns on stateful user code 
-  (e.g. due to stateful non-tracer values entering branches, see `f(x) = randn() > 0.5 ? x : 0`), 
-  we try to support as much of it as possible. 
-  Overloads therefore can't assume non-tracer values to stay constant and instead need to return conservative patterns.
+- Overloads must ignore scalar values of non-tracer inputs.
   *(While not set in stone, changing this rule in the future would require a breaking release.)*
 - Sparsity should be prioritized over performance. We assume global sparsity detection can be amortized.
 - `MethodError`s due to missing overloads can be avoided by returning a very conservative sparsity pattern.

--- a/docs/src/internals/adding_overloads.md
+++ b/docs/src/internals/adding_overloads.md
@@ -195,9 +195,9 @@ If such an overload is necessary (e.g. for array inputs), it should follow the f
 
 - Overloads must return conservative sparsity patterns (no false negatives) over the entire input domain.
 - Tracers must error instead of entering branches in user code. 
-  This requires that overloads return tracers instead of `Bool` (or numbers), 
+  This requires that overloaded functions return tracers instead of `Bool` (or numbers), 
   as the former are designed to error in comparisons.
-- Overloads must ignore values of non-tracer inputs. 
+- Overloads must ignore scalar values of non-tracer inputs. 
   While SCT can't guarantee conserservative sparsity patterns on stateful user code 
   (e.g. due to stateful non-tracer values entering branches, see `f(x) = randn() > 0.5 ? x : 0`), 
   we try to support as much of it as possible. 

--- a/docs/src/user/limitations.md
+++ b/docs/src/user/limitations.md
@@ -136,7 +136,7 @@ We provide some common examples:
 
     As motivated in the section above, global sparsity detection isn't allowed to hit any branching code.
     While SCT's overloads try to avoid branches by throwing errors, they can in some cases be entered by stateful functions.
-    Let's look at a function whose output doesn't only depend on the input `x`, but also on an internal state, in this case a random number:
+    Let's look at a function whose output doesn't only depend on the input `x`, but also on an internal state (in this case a random number):
 
     ```@repl stateful
     using SparseConnectivityTracer
@@ -148,7 +148,7 @@ We provide some common examples:
 
     SCT cannot return the correct global sparsity pattern `[1 1]` for this code.
 
-    This issue can be circumvented by [adding an overload](@ref adding-overloads) on `stateful_function` that returns a conservative pattern.
+    This issue can be circumvented by [adding an overload](@ref adding-overloads) on `f` that returns a conservative pattern.
 
 !!! details "Example: Stateful mutable caches"
 

--- a/docs/src/user/limitations.md
+++ b/docs/src/user/limitations.md
@@ -186,4 +186,7 @@ We provide some common examples:
     pattern1 = jacobian_sparsity(f, [1, 2], TracerSparsityDetector())
     ```
 
-    *(Note that this conservative behavior on dense arrays could be changed in a future breaking release.)*
+    However, such guarantees can't be made for arbitrary cache types (like the `SparseMatrixCSC` above).
+
+    *(Note that the conservative behavior on dense arrays could be changed in a future breaking release.)*
+

--- a/docs/src/user/limitations.md
+++ b/docs/src/user/limitations.md
@@ -147,7 +147,6 @@ We provide some common examples:
     ```
 
     SCT cannot return the correct global sparsity pattern `[1 1]` for this code.
-
     This issue can be circumvented by [adding an overload](@ref adding-overloads) on `f` that returns a conservative pattern.
 
 !!! details "Example: Stateful mutable caches"
@@ -158,18 +157,20 @@ We provide some common examples:
     ```@repl stateful2
     using SparseConnectivityTracer, SparseArrays
 
-    A_cache = sparse([1 0; 0 1])
+    A_cache = sparse([2 0; 0 3])
 
     f(x) = A_cache * x;
 
     pattern1 = jacobian_sparsity(f, [1, 2], TracerSparsityDetector())
     ```
 
+    #### Invalidation of global sparsity patterns 
+
     While this sparsity pattern is correct at the time of detection,
     it can be invalidated by mutating the array `A_cache`:
 
     ```@repl stateful2
-    A_cache[1, 2] = 3;
+    A_cache[1, 2] = 4;
 
     A_cache
 
@@ -178,15 +179,16 @@ We provide some common examples:
 
     With the wisdom of hindsight, `pattern1` can therefore be seen as "non-conservative".
 
-    For dense caches of type `Array`, SCT tries to circumvent this issue by returning a conservative sparsity pattern:
+    #### Exception: Dense arrays
+
+    For dense caches of type `Array` (including `Matrix` and `Vector`), SCT tries to circumvent this issue by returning a conservative sparsity pattern
+    *(note that this behavior could be changed in a future breaking release)*:
 
     ```@repl stateful2
-    A_cache = [1 0; 0 1]
+    A_cache = [2 0; 0 3]
 
     pattern1 = jacobian_sparsity(f, [1, 2], TracerSparsityDetector())
     ```
 
     However, such guarantees can't be made for arbitrary cache types (like the `SparseMatrixCSC` above).
-
-    *(Note that the conservative behavior on dense arrays could be changed in a future breaking release.)*
-
+    

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -108,12 +108,6 @@ function is_der1_arg2_zero_global end
 function is_der2_arg2_zero_global end
 function is_der_cross_zero_global end
 
-# Fallbacks for global differentiability for non-tracer (auxilliary) inputs
-is_der1_arg1_zero_global_aux2(f::F, y) where {F} = is_der1_arg1_zero_global(f)
-is_der2_arg1_zero_global_aux2(f::F, y) where {F} = is_der2_arg1_zero_global(f)
-is_der1_arg2_zero_global_aux1(f::F, x) where {F} = is_der1_arg2_zero_global(f)
-is_der2_arg2_zero_global_aux1(f::F, x) where {F} = is_der2_arg2_zero_global(f)
-
 # Fallbacks for local derivatives:
 is_der1_arg1_zero_local(f::F, x, y) where {F} = is_der1_arg1_zero_global(f)
 is_der2_arg1_zero_local(f::F, x, y) where {F} = is_der2_arg1_zero_global(f)
@@ -254,9 +248,6 @@ end
 # gradient of x*y: [y x]
 is_der1_arg1_zero_local(::typeof(*), x, y) = iszero(y)
 is_der1_arg2_zero_local(::typeof(*), x, y) = iszero(x)
-# NOTE: temporarily disabled (see PR #248)
-# is_der1_arg1_zero_global_aux2(::typeof(*), y) = iszero(y)
-# is_der1_arg2_zero_global_aux1(::typeof(*), x) = iszero(x)
 
 # ops_2_to_1_ffz: 
 # ∂f/∂x    != 0

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -155,16 +155,12 @@ function generate_code_gradient_2_to_1_typed(
 
     expr_tracer_type = quote
         function $M.$fname(tx::$SCT.GradientTracer, y::$Z)
-            is_der1_arg1_zero = $SCT.is_der1_arg1_zero_global_aux2($M.$fname, y)
-            return @noinline $SCT.gradient_tracer_1_to_1(
-                tx, is_der1_arg1_zero
-            )
+            return @noinline $SCT.gradient_tracer_1_to_1(tx, is_der1_arg1_zero_g)
         end
     end
     expr_type_tracer = quote
         function $M.$fname(x::$Z, ty::$SCT.GradientTracer)
-            is_der1_arg2_zero = $SCT.is_der1_arg2_zero_global_aux1($M.$fname, x)
-            return @noinline $SCT.gradient_tracer_1_to_1(ty, is_der1_arg2_zero)
+            return @noinline $SCT.gradient_tracer_1_to_1(ty, is_der1_arg2_zero_g)
         end
     end
 

--- a/src/overloads/gradient_tracer.jl
+++ b/src/overloads/gradient_tracer.jl
@@ -155,12 +155,12 @@ function generate_code_gradient_2_to_1_typed(
 
     expr_tracer_type = quote
         function $M.$fname(tx::$SCT.GradientTracer, y::$Z)
-            return @noinline $SCT.gradient_tracer_1_to_1(tx, is_der1_arg1_zero_g)
+            return @noinline $SCT.gradient_tracer_1_to_1(tx, $is_der1_arg1_zero_g)
         end
     end
     expr_type_tracer = quote
         function $M.$fname(x::$Z, ty::$SCT.GradientTracer)
-            return @noinline $SCT.gradient_tracer_1_to_1(ty, is_der1_arg2_zero_g)
+            return @noinline $SCT.gradient_tracer_1_to_1(ty, $is_der1_arg2_zero_g)
         end
     end
 

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -263,19 +263,15 @@ function generate_code_hessian_2_to_1_typed(
 
     expr_tracer_type = quote
         function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
-            is_der1_arg1_zero = $SCT.is_der1_arg1_zero_global_aux2($M.$fname, y)
-            is_der2_arg1_zero = $SCT.is_der2_arg1_zero_global_aux2($M.$fname, y)
             return @noinline $SCT.hessian_tracer_1_to_1(
-                tx, is_der1_arg1_zero, is_der2_arg1_zero
+                tx, is_der1_arg1_zero_g, is_der2_arg1_zero_g
             )
         end
     end
     expr_type_tracer = quote
         function $M.$fname(x::$Z, ty::$SCT.HessianTracer)
-            is_der1_arg2_zero = $SCT.is_der1_arg2_zero_global_aux1($M.$fname, x)
-            is_der2_arg2_zero = $SCT.is_der2_arg2_zero_global_aux1($M.$fname, x)
             return @noinline $SCT.hessian_tracer_1_to_1(
-                ty, is_der1_arg2_zero, is_der2_arg2_zero
+                ty, is_der1_arg2_zero_g, is_der2_arg2_zero_g
             )
         end
     end

--- a/src/overloads/hessian_tracer.jl
+++ b/src/overloads/hessian_tracer.jl
@@ -264,14 +264,14 @@ function generate_code_hessian_2_to_1_typed(
     expr_tracer_type = quote
         function $M.$fname(tx::$SCT.HessianTracer, y::$Z)
             return @noinline $SCT.hessian_tracer_1_to_1(
-                tx, is_der1_arg1_zero_g, is_der2_arg1_zero_g
+                tx, $is_der1_arg1_zero_g, $is_der2_arg1_zero_g
             )
         end
     end
     expr_type_tracer = quote
         function $M.$fname(x::$Z, ty::$SCT.HessianTracer)
             return @noinline $SCT.hessian_tracer_1_to_1(
-                ty, is_der1_arg2_zero_g, is_der2_arg2_zero_g
+                ty, $is_der1_arg2_zero_g, $is_der2_arg2_zero_g
             )
         end
     end

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -169,12 +169,12 @@ T = GradientTracer{P}
             ]
         end
 
-        # NOTE: temporarily disabled (see PR #248)
-        @testset "Multiplication by zero" begin
-            f1(x) = [0 * x[1]]
-            @test_skip J(f1, [1.0]) == [0;;]
-            f2(x) = Matrix(I(length(x))) * x
-            @test_skip J(f2, ones(10)) == I(10)
+        # NOTE: If these tests fail, changes might be breaking on stateful code (see PR #248).
+        @testset "Ignore multiplication by zero" begin
+            f(x) = [0 * x[1]]
+            @test J(f, [1.0]) == [1;;]
+            f(x) = [x[1] * 0]
+            @test J(f, [1.0]) == [1;;]
         end
 
         yield()

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -171,10 +171,10 @@ T = GradientTracer{P}
 
         # NOTE: If these tests fail, changes might be breaking on stateful code (see PR #248).
         @testset "Ignore multiplication by zero" begin
-            f(x) = [0 * x[1]]
-            @test J(f, [1.0]) == [1;;]
-            f(x) = [x[1] * 0]
-            @test J(f, [1.0]) == [1;;]
+            f1(x) = [0 * x[1]]
+            @test J(f1, [1.0]) == [1;;]
+            f2(x) = [x[1] * 0]
+            @test J(f2, [1.0]) == [1;;]
         end
 
         yield()

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -269,14 +269,12 @@ D = Dual{Int, T}
             @test_throws TypeError H(x -> x[1] > x[2] ? x[1]^x[2] : x[3] * x[4], rand(4))
         end
 
-        # NOTE: temporarily disabled (see PR #248)
-        @testset "Multiplication by zero" begin
-            if !Bool(shared(T))
-                f1(x) = 0 * x[1]^2
-                @test_skip H(f1, [1.0]) == [0;;]
-                f2(x) = dot(x, Matrix(I(length(x))), x)
-                @test_skip H(f2, ones(10)) == I(10)
-            end
+        # NOTE: If these tests fail, changes might be breaking on stateful code (see PR #248).
+        @testset "Ignore multiplication by zero" begin
+            f(x) = 0 * x[1]^2
+            @test H(f, [1.0]) == [1;;]
+            f(x) = x[1]^2 * 0
+            @test H(f, [1.0]) == [1;;]
         end
 
         yield()

--- a/test/test_hessian.jl
+++ b/test/test_hessian.jl
@@ -271,10 +271,10 @@ D = Dual{Int, T}
 
         # NOTE: If these tests fail, changes might be breaking on stateful code (see PR #248).
         @testset "Ignore multiplication by zero" begin
-            f(x) = 0 * x[1]^2
-            @test H(f, [1.0]) == [1;;]
-            f(x) = x[1]^2 * 0
-            @test H(f, [1.0]) == [1;;]
+            f1(x) = 0 * x[1]^2
+            @test H(f1, [1.0]) == [1;;]
+            f2(x) = x[1]^2 * 0
+            @test H(f2, [1.0]) == [1;;]
         end
 
         yield()


### PR DESCRIPTION
* Make changes in #248 permanent by reverting #247.
* Document design principles, which could use a second pair of eyes (ping @gdalle).