### PR TITLE
mention PreallocationTools.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ julia> hessian_sparsity(g, x, detector)
  ⋅  1  ⋅  ⋅  1
 ```
 
-For more detailed examples, take a look at the [documentation](https://adrianhill.de/SparseConnectivityTracer.jl/dev).
+For more detailed examples, take a look at the [documentation](https://adrianhill.de/SparseConnectivityTracer.jl/stable).
 
 ### Local tracing
 

--- a/docs/src/user/api.md
+++ b/docs/src/user/api.md
@@ -33,3 +33,9 @@ hessian_eltype
 jacobian_buffer
 hessian_buffer
 ```
+
+Please note that the `DiffCache` from
+[PreallocationTools.jl](https://github.com/SciML/PreallocationTools.jl)
+can be used to make caches compatible with both
+[ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and
+[SparseConnectivityTracer.jl](https://github.com/adrhill/SparseConnectivityTracer.jl/).


### PR DESCRIPTION
Closes #250 and should only be merged after https://github.com/SciML/PreallocationTools.jl/pull/122 has been merged and a new version of PreallocationTools.jl has been registered.