### PR TITLE
fix(overload): `NaNMath.pow` method ambiguity

### DIFF
--- a/ext/SparseConnectivityTracerNaNMathExt.jl
+++ b/ext/SparseConnectivityTracerNaNMathExt.jl
@@ -81,6 +81,9 @@ ops_2_to_1 = union(ops_2_to_1_ssc, ops_2_to_1_ffz)
 eval(SCT.generate_code_1_to_1(:NaNMath, ops_1_to_1))
 eval(SCT.generate_code_2_to_1(:NaNMath, ops_2_to_1))
 
+## Special overloads to avoid ambiguity errors
+eval(SCT.generate_code_2_to_1_typed(:NaNMath, NaNMath.pow, Integer))
+
 ## List operators for later testing
 SCT.test_operators_1_to_1(::Val{:NaNMath}) = ops_1_to_1
 SCT.test_operators_2_to_1(::Val{:NaNMath}) = ops_2_to_1

--- a/test/ext/test_NaNMath.jl
+++ b/test/ext/test_NaNMath.jl
@@ -32,6 +32,7 @@ nan_1_to_1 = (
     end
     @testset "2-to-1 functions" begin
         @test J(x -> NaNMath.pow(x[1], x[2]), rand(3)) == [1 1 0]
+        @test J(x -> NaNMath.pow(x[1], 2), rand(3)) == [1 0 0]  # Issue #291
         @test J(x -> NaNMath.max(x[1], x[2]), rand(3)) == [1 1 0]
         @test J(x -> NaNMath.min(x[1], x[2]), rand(3)) == [1 1 0]
     end
@@ -60,6 +61,7 @@ end
     end
     @testset "2-to-1 functions" begin
         @test H(x -> NaNMath.pow(x[1], x[2]), rand(3)) == [1 1 0; 1 1 0; 0 0 0]
+        @test H(x -> NaNMath.pow(x[1], 2), rand(3)) == [1 0 0; 0 0 0; 0 0 0]  # Issue #291
         @test H(x -> NaNMath.max(x[1], x[2]), rand(3)) == zeros(Bool, 3, 3)
         @test H(x -> NaNMath.min(x[1], x[2]), rand(3)) == zeros(Bool, 3, 3)
     end


### PR DESCRIPTION
Fix #291.