### PR TITLE
ci(fix): cap BenchmarkTools.jl compat at `v1.6`

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -12,3 +12,6 @@ PkgJogger = "10150987-6cc1-4b76-abee-b1c1cbd91c01"
 SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+
+[compat]
+BenchmarkTools = "~1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -30,6 +30,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+BenchmarkTools = "~1.6"
 ExplicitImports = "1"
 JET = "0.9, 0.10, 0.11"
 JLD2 = "0.6"


### PR DESCRIPTION
Fixes the failing `Benchmarks` CI group on `main`.

- `BenchmarkTools` v1.7+ changed the signature of its internally generated `##sample#` functions, which breaks `PkgJogger` v0.6.0's `@test_benchmarks` with a `MethodError`. The last green run on `main` resolved `BenchmarkTools` v1.6.3; the first red one resolved v1.8.0 with no other relevant version changes.
- Cap `BenchmarkTools` at `~1.6` in `test/Project.toml` and `benchmark/Project.toml` until `PkgJogger` supports newer `BenchmarkTools` releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)